### PR TITLE
fix(python): add libpq-dev

### DIFF
--- a/src/usr/local/buildpack/tools/python.sh
+++ b/src/usr/local/buildpack/tools/python.sh
@@ -44,6 +44,7 @@ if [[ -z "${tool_path}" ]]; then
       libbz2-dev \
       libffi-dev \
       liblzma-dev \
+      libpq-dev \
       libreadline-dev \
       libsqlite3-dev \
       libssl-dev \


### PR DESCRIPTION
Adds `libpq` when `python` is installed, as per https://github.com/renovatebot/renovate/issues/9485#issuecomment-817132534