### PR TITLE
feat: simplify env and shell handling

### DIFF
--- a/src/usr/local/bin/docker-entrypoint.sh
+++ b/src/usr/local/bin/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -f "/usr/local/etc/env" && -z "${BUILDPACK+x}" ]]; then
+if [[ -f "/usr/local/etc/env" && -z "${CONTAINERBASE_ENV+x}" ]]; then
     # shellcheck source=/dev/null
   . /usr/local/etc/env
 fi

--- a/src/usr/local/bin/install-buildpack
+++ b/src/usr/local/bin/install-buildpack
@@ -23,8 +23,8 @@ if [[ "${BASH_ENV}" != "${ENV_FILE}" ]]; then
 fi
 
 # no duplicate installs
-if [[ -n "${BUILDPACK+x}" ]]; then
-  echo "BUILDPACK defined - skipping: ${BUILDPACK}"
+if [[ -n "${CONTAINERBASE_ENV+x}" ]]; then
+  echo "CONTAINERBASE_ENV defined - skipping: ${CONTAINERBASE_ENV}"
   exit 1;
 fi
 

--- a/src/usr/local/buildpack/tools/v2/python.sh
+++ b/src/usr/local/buildpack/tools/v2/python.sh
@@ -75,12 +75,12 @@ function link_tool () {
   export_tool_path "${versioned_tool_path}/bin"
 
   # TODO: fix me, currently required for global pip
-  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
-  shell_wrapper "${TOOL_NAME}${MAJOR}" "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
-  shell_wrapper "${TOOL_NAME}${MAJOR}.${MINOR}" "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
-  shell_wrapper pip "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
-  shell_wrapper "pip${MAJOR}" "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
-  shell_wrapper "pip${MAJOR}.${MINOR}" "${versioned_tool_path}" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper "${TOOL_NAME}${MAJOR}" "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper "${TOOL_NAME}${MAJOR}.${MINOR}" "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper pip "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper "pip${MAJOR}" "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
+  shell_wrapper "pip${MAJOR}.${MINOR}" "${versioned_tool_path}/bin" "PYTHONHOME=${versioned_tool_path}"
 
   python --version
   pip --version

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -32,7 +32,7 @@ check_debug() {
 }
 check_debug
 
-if [[ -z "${BUILDPACK+x}" ]]; then
+if [[ -z "${CONTAINERBASE_ENV+x}" ]]; then
   refreshenv
 fi
 

--- a/src/usr/local/buildpack/utils/environment.sh
+++ b/src/usr/local/buildpack/utils/environment.sh
@@ -79,7 +79,7 @@ function setup_env_files () {
   install_dir=$(get_install_dir)
 
   cat >> "$ENV_FILE" <<- EOM
-export BUILDPACK=1 USER_NAME="${USER_NAME}" USER_ID="${USER_ID}" USER_HOME="${USER_HOME}"
+export BUILDPACK=1 CONTAINERBASE=1 USER_NAME="${USER_NAME}" USER_ID="${USER_ID}" USER_HOME="${USER_HOME}" CONTAINERBASE_ENV=1
 
 env_dirs=("/usr/local" "/opt/buildpack" "\${USER_HOME}")
 
@@ -104,7 +104,7 @@ unset env_dirs
 EOM
 
   cat >> "${BASH_RC}" <<- EOM
-if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
+if [[ -r "$ENV_FILE" && -z "${CONTAINERBASE_ENV+x}" ]]; then
   . $ENV_FILE
 fi
 EOM

--- a/src/usr/local/buildpack/utils/linking.sh
+++ b/src/usr/local/buildpack/utils/linking.sh
@@ -18,7 +18,7 @@ function shell_wrapper () {
   cat > "$TARGET" <<- EOM
 #!/bin/bash
 
-if [[ -r "$ENV_FILE" && -z "${BUILDPACK+x}" ]]; then
+if [[ -z "\${CONTAINERBASE_ENV+x}" ]]; then
   . $ENV_FILE
 fi
 EOM

--- a/src/usr/local/buildpack/utils/ruby.sh
+++ b/src/usr/local/buildpack/utils/ruby.sh
@@ -18,25 +18,15 @@ function gem_install() {
   fi
 }
 
-
-function gem_link_wrapper() {
-  link_wrapper "${1:-$TOOL_NAME}" "$tool_path/bin"
-}
-
 function gem_shell_wrapper () {
-  local install_dir
   local ruby_path
   local ruby_version
   local ruby_minor_version
   local tool_name
   local tool_path
-  local tool_target
-  local tool_wrapper
 
-  install_dir=$(get_install_dir)
   tool_name=${1:-$TOOL_NAME}
   tool_path=$(find_versioned_tool_path)
-  tool_wrapper=${install_dir}/bin/${tool_name}
   ruby_path=/usr/local/ruby
 
   # TODO: make generic
@@ -47,14 +37,6 @@ function gem_shell_wrapper () {
   fi
 
   ruby_minor_version="${BASH_REMATCH[1]}.${BASH_REMATCH[3]}"
-  tool_target="${tool_path}/bin/${tool_name}"
-  check_command "${tool_target}"
-  cat > "$tool_wrapper" <<- EOM
-#!/bin/bash
 
-export GEM_PATH=${tool_path}:${ruby_path}/${ruby_version}/lib/ruby/gems/${ruby_minor_version}.0 PATH=${tool_path}/bin:\$PATH
-
-${tool_target} "\$@"
-EOM
-  chmod 775 "$tool_wrapper"
+  shell_wrapper "$tool_name" "${tool_path}/bin" "GEM_PATH=${tool_path}:${ruby_path}/${ruby_version}/lib/ruby/gems/${ruby_minor_version}.0 PATH=${tool_path}/bin:\$PATH"
 }

--- a/test/ruby/Dockerfile
+++ b/test/ruby/Dockerfile
@@ -101,7 +101,7 @@ RUN install-tool bundler
 
 RUN set -ex; \
   bundler --version | grep ${BUNDLER_VERSION}; \
-  [ "$(command -v bundler)" = "$USER_HOME/bin/bundler" ] && echo "works" || exit 1;
+  [ "$(command -v bundler)" = "/usr/local/bin/bundler" ] && echo "works" || exit 1;
 
 RUN bundler env
 


### PR DESCRIPTION
- use new env  `CONTAINERBASE_ENV` to detect if we've loaded our env file
- export `CONTAINERBASE=1` additionally to `BUILDPACK=1` for external tool usage (like renovate)
- ruby and python are now used default shell wrapper