### PR TITLE
feat: add new tool vendir

### DIFF
--- a/src/usr/local/buildpack/tools/v2/vendir.sh
+++ b/src/usr/local/buildpack/tools/v2/vendir.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function install_tool () {
+  local versioned_tool_path
+  versioned_tool_path=$(create_versioned_tool_path)
+
+  create_folder "${versioned_tool_path}/bin"
+
+  local file
+  file=$(get_from_url "https://github.com/vmware-tanzu/carvel-vendir/releases/download/v${TOOL_VERSION}/vendir-linux-amd64")
+  create_folder "${versioned_tool_path}/bin"
+  cp "${file}" "${versioned_tool_path}/bin/vendir"
+  chmod +x "${versioned_tool_path}/bin/vendir"
+}
+
+function link_tool () {
+  local versioned_tool_path
+  versioned_tool_path=$(find_versioned_tool_path)
+
+  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin"
+  vendir --version
+}

--- a/test/Dockerfile.bionic
+++ b/test/Dockerfile.bionic
@@ -104,3 +104,6 @@ RUN git lfs version
 
 # renovate: datasource=github-releases packageName=jsonnet-bundler/jsonnet-bundler
 RUN install-tool jb v0.5.1
+
+# renovate: datasource=github-releases packageName=vmware-tanzu/carvel-vendir
+RUN install-tool vendir v0.32.2

--- a/test/Dockerfile.jammy
+++ b/test/Dockerfile.jammy
@@ -104,3 +104,6 @@ RUN git lfs version
 
 # renovate: datasource=github-releases packageName=jsonnet-bundler/jsonnet-bundler
 RUN install-tool jb v0.5.1
+
+# renovate: datasource=github-releases packageName=vmware-tanzu/carvel-vendir
+RUN install-tool vendir v0.32.2

--- a/test/vendir/Dockerfile
+++ b/test/vendir/Dockerfile
@@ -1,0 +1,35 @@
+ARG IMAGE=containerbase/buildpack
+FROM ${IMAGE} as build
+
+RUN touch /.dummy
+
+# renovate: datasource=github-releases packageName=vmware-tanzu/carvel-vendir
+ARG VENDIR_VERSION=0.32.2
+
+
+FROM build as testa
+
+RUN install-tool vendir "v${VENDIR_VERSION}"
+
+RUN set -ex; vendir --version
+
+SHELL [ "/bin/sh", "-c" ]
+
+RUN vendir --version | grep "${VENDIR_VERSION}"
+
+USER 1000
+
+RUN vendir --version | grep "${VENDIR_VERSION}"
+
+# even more restricted
+USER 1000:1000
+
+RUN vendir --version | grep "${VENDIR_VERSION}"
+
+
+#------------------------------------------------------------------
+# final
+#------------------------------------------------------------------
+FROM build
+
+COPY --from=testa /.dummy /.dummy


### PR DESCRIPTION
Adds install script for the [vendir](https://carvel.dev/vendir/docs/v0.32.0/install/) tool.


See: https://github.com/renovatebot/renovate/issues/17711