### PR TITLE
feat: rename docker image to `containerbase/base`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM containerbase/node:18.13.0@sha256:da4f6003b6ad6336c0860adc3ad14aaf57798d80aca02b9350a99373bd6810c8
 
 # renovate: datasource=npm
-RUN install-tool yarn 1.22.19
+RUN install-tool corepack 0.15.3
 
 USER root
 RUN install-apt shellcheck

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "buildpack",
+  "name": "containerbase",
   "dockerFile": "Dockerfile",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   DRY_RUN: ${{ github.ref_name != 'main' }}
   OWNER: ${{ github.repository_owner }}
-  FILE: buildpack
+  FILE: base
   DOCKER_BUILDKIT: 1
   NODE_VERSION: 18.13.0 # renovate: datasource=node depName=node
   BUILDPACK_VERSION: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   OWNER: ${{ github.repository_owner }}
-  FILE: buildpack
+  FILE: base
   DOCKER_BUILDKIT: 1
   NODE_VERSION: 18.13.0 # renovate: datasource=node depName=node
   BUILDPACK_VERSION: ${{ github.sha }}

--- a/.releaserc
+++ b/.releaserc
@@ -90,5 +90,7 @@
     ]
   },
   "tagFormat": "${version}",
-  "branches": ["main"]
+  "branches": [
+    "main"
+  ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ARG CACHE_WEEK
 ARG BUILDPACK_VERSION
 
 LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
-  org.opencontainers.image.source="https://github.com/containerbase/buildpack"
+  org.opencontainers.image.source="https://github.com/containerbase/base"
 
-#  autoloading buildpack env
+#  autoloading containerbase env
 ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/ubuntu/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-![Build status](https://github.com/containerbase/base/actions/workflows/build-push.yml/badge.svg)
-![Docker Image Size (latest)](https://img.shields.io/docker/image-size/containerbase/buildpack/latest)
-![GitHub](https://img.shields.io/github/license/containerbase/base)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/containerbase/base)
-
 # containerbase base
 
-This repository is the source for the Docker Hub image `containerbase/buildpack`, which is to be renamed to `containerbase/base`.
+![Build status](https://github.com/containerbase/base/actions/workflows/build-push.yml/badge.svg)
+![Docker Image Size (latest)](https://img.shields.io/docker/image-size/containerbase/base/latest)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/containerbase/base)
+![Licence: MIT](https://img.shields.io/github/license/containerbase/base)
+
+This repository is the source for the Docker images [`containerbase/base`](https://hub.docker.com/r/containerbase/base) and `ghcr.io/containerbase/base`.
 It is not associated with or compatible with the `buildpacks.io` project.
-Commits to `main` branch are automatically built and published.
+Commits to `main` branch are automatically build and published.
 
 ## Local development
 
@@ -17,7 +17,7 @@ You should use
 
 ### Base image
 
-If you make changes to the [`src`](./src/) folder or the [`Dockerfile`](./Dockerfile), you need to rebuild the `containerbase/buildpack` image.
+If you make changes to the [`src`](./src/) folder or the [`Dockerfile`](./Dockerfile), you need to rebuild the `containerbase/base` image.
 
 ```sh
 docker buildx bake
@@ -58,11 +58,11 @@ You can simply export `APT_HTTP_PROXY` to your local env and our build tools wil
 
 ## Custom base image
 
-To use a custom base image with `containerbase/buildpack` checkout [custom-base-image](./docs/custom-base-image.md) docs.
+To use a custom base image with `containerbase/base` checkout [custom-base-image](./docs/custom-base-image.md) docs.
 
 ### Custom Root CA Certificates
 
-To add custom root certificates to the `containerbase/buildpack` base image checkout [custom-root-ca](./docs/custom-root-ca.md) docs.
+To add custom root certificates to the `containerbase/base` base image checkout [custom-root-ca](./docs/custom-root-ca.md) docs.
 
 ### Temporary disable tool installer
 
@@ -71,7 +71,7 @@ To temporary disable / skip some tool installer set the build arg `IGNORED_TOOLS
 The following sample will skip the installation of `powershell` and `node`.
 
 ```Dockerfile
-FROM containerbase/buildpack
+FROM containerbase/base
 
 ARG IGNORED_TOOLS=powershell,node
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,7 +2,7 @@ variable "OWNER" {
   default = "containerbase"
 }
 variable "FILE" {
-  default = "buildpack"
+  default = "base"
 }
 variable "TAG" {
   default = "latest"
@@ -32,7 +32,7 @@ group "default" {
 }
 
 group "push" {
-  targets = ["push-ghcr", "push-hub", "push-cache"]
+  targets = ["push-ghcr", "push-hub", "push-legacy", "push-cache"]
 }
 
 group "test" {
@@ -47,10 +47,10 @@ group "test-distro" {
 target "settings" {
   context = "."
   args = {
-    APT_HTTP_PROXY = "${APT_HTTP_PROXY}"
-    BUILDPACK_DEBUG = "${BUILDPACK_DEBUG}"
+    APT_HTTP_PROXY    = "${APT_HTTP_PROXY}"
+    BUILDPACK_DEBUG   = "${BUILDPACK_DEBUG}"
     BUILDPACK_VERSION = "${BUILDPACK_VERSION}"
-    GITHUB_TOKEN = "${GITHUB_TOKEN}"
+    GITHUB_TOKEN      = "${GITHUB_TOKEN}"
   }
 }
 
@@ -105,4 +105,16 @@ target "push-hub" {
   inherits = ["settings", "cache"]
   output   = ["type=registry"]
   tags     = ["${OWNER}/${FILE}", "${OWNER}/${FILE}:${TAG}"]
+}
+
+// TODO: remove on next major
+target "push-legacy" {
+  inherits = ["settings", "cache"]
+  output   = ["type=registry"]
+  tags = [
+    "ghcr.io/${OWNER}/buildpack",
+    "ghcr.io/${OWNER}/buildpack:${TAG}",
+    "${OWNER}/buildpack",
+    "${OWNER}/buildpack:${TAG}"
+  ]
 }

--- a/docs/custom-base-image.md
+++ b/docs/custom-base-image.md
@@ -1,11 +1,11 @@
 # Custom base image
 
-The following sample can be used to create a `containerbase/buildpack` based image which does not extend `containerbase/buildpack` directly.
+The following sample can be used to create a `containerbase/base` based image which does not extend `containerbase/base` directly.
 Currently only ubuntu focal and jammy based amd64 distro are suported.
 
-You can also use our buildpack from GitHub container registry as `ghcr.io/containerbase/buildpack`.
-`containerbase/buildpack` and `ghcr.io/containerbase/buildpack` are exchangeble.
-You should always use a specific version which can be found at [docker hub](https://hub.docker.com/r/containerbase/buildpack/tags) or at [GitHub container registry](ghcr.io/containerbase/buildpack)
+You can also use our buildpack from GitHub container registry as `ghcr.io/containerbase/base`.
+`containerbase/base` and `ghcr.io/containerbase/base` are exchangeble.
+You should always use a specific version which can be found at [docker hub](https://hub.docker.com/r/containerbase/base/tags) or at [GitHub container registry](ghcr.io/containerbase/base)
 
 ## Default user name and id
 
@@ -13,7 +13,7 @@ Use this template for using a custom base image with our default user named `ubu
 
 ```dockerfile
 # This buildpack is used for tool intallation and user/directory setup
-FROM containerbase/buildpack AS buildpack
+FROM containerbase/base AS buildpack
 
 FROM amd64/ubuntu:focal as base
 
@@ -33,7 +33,7 @@ COPY my-root-ca.crt /usr/local/share/ca-certificates/my-root-ca.crt
 
 # Set up buildpack
 COPY --from=buildpack /usr/local/bin/ /usr/local/bin/
-COPY --from=buildpack /usr/local/buildpack/ /usr/local/buildpack/
+COPY --from=buildpack /usr/local/base/ /usr/local/base/
 RUN install-buildpack
 
 
@@ -56,7 +56,7 @@ You can also customize username or userid by using this template.
 
 ```dockerfile
 # This buildpack is used for tool intallation and user/directory setup
-FROM containerbase/buildpack AS buildpack
+FROM containerbase/base AS buildpack
 
 FROM amd64/ubuntu:focal as base
 
@@ -79,7 +79,7 @@ COPY my-root-ca.crt /usr/local/share/ca-certificates/my-root-ca.crt
 
 # Set up buildpack
 COPY --from=buildpack /usr/local/bin/ /usr/local/bin/
-COPY --from=buildpack /usr/local/buildpack/ /usr/local/buildpack/
+COPY --from=buildpack /usr/local/base/ /usr/local/base/
 RUN install-buildpack
 
 

--- a/docs/custom-root-ca.md
+++ b/docs/custom-root-ca.md
@@ -9,7 +9,7 @@ If you are using a custom base image, checkout [Custom base image](./custom-base
 This is the easiest method.
 
 ```Dockerfile
-FROM containerbase/buildpack
+FROM containerbase/base
 
 COPY my-root-ca.crt /usr/local/share/ca-certificates/my-root-ca.crt
 RUN update-ca-certificates
@@ -18,14 +18,14 @@ RUN update-ca-certificates
 ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/my-root-ca.crt
 ```
 
-### Java
+### Buildtime Java install
 
 Buildpack will create a central certificate store at `/opt/buildpack/ssl/cacerts` when preparing Java (`prepare-tool java`).
 This will be used by all Java versions installed by our `install-tool`.
 So you can copy your own store like this:
 
 ```Dockerfile
-FROM containerbase/buildpack
+FROM containerbase/base
 
 COPY my-root-cert-store.jks /opt/buildpack/ssl/cacerts
 
@@ -41,10 +41,10 @@ docker run --rm -it \
   -v my-root-ca.crt:/my-root-ca.crt \
   -e SSL_CERT_FILE=/my-root-ca.crt \
   -e NODE_EXTRA_CA_CERTS=/my-root-ca.crt \
-  containerbase/buildpack bash
+  containerbase/base bash
 ```
 
-### Java
+### Runtime Java install
 
 For Java you need to mount your own certificate store to `/opt/buildpack/ssl/cacerts`.
 
@@ -54,5 +54,5 @@ docker run --rm -it \
   -v my-root-cert-store.jks:/opt/buildpack/ssl/cacerts \
   -e SSL_CERT_FILE=/my-root-ca.crt \
   -e NODE_EXTRA_CA_CERTS=/my-root-ca.crt \
-  containerbase/buildpack bash
+  containerbase/base bash
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "buildpack",
+  "name": "containerbase",
   "version": "0.0.0-semantic-release",
-  "repository": "https://github.com/containerbase/buildpack.git",
+  "repository": "https://github.com/containerbase/base.git",
   "author": "Rhys Arkins <rhys@arkins.net>",
   "contributors": [
     "Michael Kriese <michael.kriese@visualon.de>"

--- a/src/usr/local/buildpack/util.sh
+++ b/src/usr/local/buildpack/util.sh
@@ -134,7 +134,7 @@ function require_distro () {
   "focal") ;; #supported
   "jammy") #supported (partial)
     echo "WARNING: Not all tools are yet supported!" >&2
-    echo "  -> https://github.com/containerbase/buildpack/issues/361" >&2
+    echo "  -> https://github.com/containerbase/base/issues/361" >&2
     ;;
   *)
     echo "Distro not supported: ${VERSION_CODENAME}! Please use ubuntu 'focal' or 'jammy'." >&2

--- a/test/Dockerfile.jammy
+++ b/test/Dockerfile.jammy
@@ -5,10 +5,7 @@ FROM ubuntu:jammy as base
 
 ARG APT_HTTP_PROXY
 
-LABEL maintainer="Rhys Arkins <rhys@arkins.net>" \
-  org.opencontainers.image.source="https://github.com/containerbase/buildpack"
-
-#  autoloading buildpack env
+#  autoloading containerbase env
 ENV BASH_ENV=/usr/local/etc/env ENV=/usr/local/etc/env PATH=/home/$USER_NAME/bin:$PATH
 SHELL ["/bin/bash" , "-c"]
 

--- a/test/bash/cache.bats
+++ b/test/bash/cache.bats
@@ -144,7 +144,7 @@ teardown() {
   BUILDPACK_CACHE_DIR="${TEST_ROOT_DIR}/cache"
   mkdir -p "${BUILDPACK_CACHE_DIR}"
 
-  local file="https://github.com/containerbase/buildpack/releases/download/1.0.0/buildpack.tar.xz"
+  local file="https://github.com/containerbase/base/releases/download/1.0.0/buildpack.tar.xz"
 
   run download_file
   assert_failure
@@ -174,7 +174,7 @@ teardown() {
   BUILDPACK_CACHE_DIR="${TEST_ROOT_DIR}/cache"
   mkdir -p "${BUILDPACK_CACHE_DIR}"
 
-  local file="https://github.com/containerbase/buildpack/releases/download/1.0.0/buildpack.tar.xz"
+  local file="https://github.com/containerbase/base/releases/download/1.0.0/buildpack.tar.xz"
 
   run get_from_url "${file}"
   assert_success

--- a/test/dart/Dockerfile
+++ b/test/dart/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as base
 
 ARG APT_HTTP_PROXY

--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG BUILDPACK_DEBUG
 
 FROM ${IMAGE} as base

--- a/test/erlang/Dockerfile
+++ b/test/erlang/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as build
 
 RUN touch /.dummy

--- a/test/flutter/Dockerfile
+++ b/test/flutter/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as base
 
 ARG APT_HTTP_PROXY

--- a/test/flux/Dockerfile
+++ b/test/flux/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as build
 
 RUN touch /.dummy

--- a/test/golang/Dockerfile
+++ b/test/golang/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG APT_HTTP_PROXY
 ARG BUILDPACK_DEBUG
 

--- a/test/helm/Dockerfile
+++ b/test/helm/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as build
 
 RUN touch /.dummy

--- a/test/java/Dockerfile
+++ b/test/java/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as base
 
 RUN touch /.dummy

--- a/test/jb/Dockerfile
+++ b/test/jb/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as build
 
 RUN touch /.dummy

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as base
 
 ARG APT_HTTP_PROXY

--- a/test/nix/Dockerfile
+++ b/test/nix/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG APT_HTTP_PROXY
 ARG GITHUB_TOKEN
 

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG BUILDPACK_DEBUG
 
 FROM ${IMAGE} as build

--- a/test/php/Dockerfile
+++ b/test/php/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 FROM ${IMAGE} as base
 
 RUN touch /.dummy

--- a/test/powershell/Dockerfile
+++ b/test/powershell/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG APT_HTTP_PROXY
 
 #--------------------------------------

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG BUILDPACK_DEBUG
 
 FROM ${IMAGE} as base

--- a/test/ruby/Dockerfile
+++ b/test/ruby/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG BUILDPACK_DEBUG
 
 #--------------------------------------

--- a/test/rust/Dockerfile
+++ b/test/rust/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG BUILDPACK_DEBUG
 
 FROM ${IMAGE} as base

--- a/test/swift/Dockerfile
+++ b/test/swift/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=containerbase/buildpack
+ARG IMAGE=containerbase/base
 ARG APT_HTTP_PROXY
 
 #--------------------------------------

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,27 +883,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buildpack@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "buildpack@workspace:."
-  dependencies:
-    "@semantic-release/exec": 6.0.3
-    "@types/node": 18.11.18
-    "@types/shelljs": 0.8.11
-    bats: 1.8.2
-    bats-assert: 2.0.0
-    bats-support: 0.3.0
-    commander: 10.0.0
-    conventional-changelog-conventionalcommits: 5.0.0
-    husky: 8.0.3
-    lint-staged: 13.1.0
-    npm-run-all: 4.1.5
-    prettier: 2.8.3
-    semantic-release: 20.1.0
-    shelljs: 0.8.5
-  languageName: unknown
-  linkType: soft
-
 "builtins@npm:^5.0.0":
   version: 5.0.1
   resolution: "builtins@npm:5.0.1"
@@ -1227,6 +1206,27 @@ __metadata:
   checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
   languageName: node
   linkType: hard
+
+"containerbase@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "containerbase@workspace:."
+  dependencies:
+    "@semantic-release/exec": 6.0.3
+    "@types/node": 18.11.18
+    "@types/shelljs": 0.8.11
+    bats: 1.8.2
+    bats-assert: 2.0.0
+    bats-support: 0.3.0
+    commander: 10.0.0
+    conventional-changelog-conventionalcommits: 5.0.0
+    husky: 8.0.3
+    lint-staged: 13.1.0
+    npm-run-all: 4.1.5
+    prettier: 2.8.3
+    semantic-release: 20.1.0
+    shelljs: 0.8.5
+  languageName: unknown
+  linkType: soft
 
 "conventional-changelog-angular@npm:^5.0.0":
   version: 5.0.13


### PR DESCRIPTION
- publish image as `containerbase/base` and `ghcr.io/containerbase/base`
- publish legacy images `containerbase/buildpack` and `ghcr.io/containerbase/buildpack`
- some renamings
- #524