### PR TITLE
fix(prepare-tool): don't break early when skip tool

### DIFF
--- a/src/usr/local/buildpack/utils/prepare.sh
+++ b/src/usr/local/buildpack/utils/prepare.sh
@@ -10,7 +10,7 @@ function prepare_tools () {
 
   if [[ $(ignore_tool) -eq 1 ]]; then
     echo "Tool ignored - skipping: ${TOOL_NAME}"
-    exit 0;
+    return
   fi
 
   TOOL="${ROOT_DIR}/buildpack/tools/v2/${TOOL_NAME}.sh"


### PR DESCRIPTION
If a tool is skipped via `IGNORED_TOOLS` and we run `install-tool all` the whole process exit's early instead of preparing other tools.