### PR TITLE
fix: ensure user can overwrite tool env file

### DIFF
--- a/src/usr/local/buildpack/utils/environment.sh
+++ b/src/usr/local/buildpack/utils/environment.sh
@@ -49,7 +49,8 @@ function export_tool_env () {
     exit 1;
   fi
   export "${1}=${2}"
-  echo export "${1}=\${${1}-${2}}" >> "$install_dir"/env.d/"${TOOL_NAME}".sh
+  echo export "${1}=\${${1}-${2}}" >> "${install_dir}/env.d/${TOOL_NAME}.sh"
+  set_file_owner "${install_dir}/env.d/${TOOL_NAME}.sh" 664
 }
 
 function export_tool_path () {
@@ -71,6 +72,7 @@ function export_tool_path () {
     export PATH="$additional_path:$PATH"
     echo export PATH="$additional_path:\$PATH" >> "${install_dir}/env.d/${TOOL_NAME}.sh"
   fi
+  set_file_owner "${install_dir}/env.d/${TOOL_NAME}.sh" 664
 }
 
 function setup_env_files () {

--- a/src/usr/local/buildpack/utils/filesystem.sh
+++ b/src/usr/local/buildpack/utils/filesystem.sh
@@ -140,3 +140,20 @@ function get_umask () {
 function get_buildpack_path () {
   echo "${BUILDPACK_DIR}"
 }
+
+# Own the file by default user and make it writable for root group
+function set_file_owner() {
+  local target=${1}
+  local perms=${2:-775}
+
+  # make it writable for the owner and the group
+  if [[ -O "${target}" ]] && [ "$(stat --format '%a' "${target}")" -ne "${perms}" ] ; then
+    # make it writable for the owner and the group only if we are the owner
+    chmod "${perms}" "${target}"
+  fi
+  # make it writable for the default user
+  if [[ -O "${target}" ]] && [ "$(stat --format '%u' "${target}")" -eq "0" ] ; then
+    # make it writable for the owner and the group only if we are the owner
+    chown "${USER_ID}" "${target}"
+  fi
+}

--- a/src/usr/local/buildpack/utils/linking.sh
+++ b/src/usr/local/buildpack/utils/linking.sh
@@ -29,16 +29,7 @@ EOM
 
   echo "${SOURCE} \"\$@\"" >> "$TARGET"
 
-  # make it writable for the owner and the group
-  if [[ -O "$TARGET" ]] && [ "$(stat --format '%a' "${TARGET}")" -ne 775 ] ; then
-    # make it writable for the owner and the group only if we are the owner
-    chmod 775 "$TARGET"
-  fi
-  # make it writable for the default user
-  if [[ -O "$TARGET" ]] && [ "$(stat --format '%u' "${TARGET}")" -eq "0" ] ; then
-    # make it writable for the owner and the group only if we are the owner
-    chown "${USER_ID}" "$TARGET"
-  fi
+  set_file_owner "${TARGET}" 775
 }
 
 # use this for simple symlink to /usr/local/bin

--- a/test/bash/environment.bats
+++ b/test/bash/environment.bats
@@ -40,6 +40,7 @@ teardown() {
   run cat "${install_dir}/env.d/foo.sh"
   assert_success
   assert_output --partial "FOO_HOME=\${FOO_HOME-123}"
+  assert [ $(stat --format '%a' "${install_dir}/env.d/foo.sh") -eq 664 ]
 
   run reset_tool_env
   assert_success

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -147,8 +147,6 @@ RUN set -ex; \
 #--------------------------------------
 FROM build-rootless as testb
 
-ARG CONTAINERBASE_DEBUG
-
 # renovate: datasource=pypi
 RUN install-pip pipenv 2023.4.20
 
@@ -178,6 +176,8 @@ RUN set -ex \
 # test pipenv-b: pipenv (multiple python)
 #--------------------------------------
 FROM build as test-pipenv-b
+
+USER 1001
 
 # Do not update minor
 RUN install-tool python 3.8.13


### PR DESCRIPTION
Currently when we install `python` as root, the tool env file is only writable as root.
So we can't install another python as user, because we can't overwrite the tool env.

This PR now ensures that the env file is owned by the user and and is writable by root group.