### PR TITLE
fix(python): support older pip versions for pep517

### DIFF
--- a/src/usr/local/buildpack/tools/v2/python.sh
+++ b/src/usr/local/buildpack/tools/v2/python.sh
@@ -86,12 +86,11 @@ function install_tool () {
   fix_python_shebangs
 
   # install latest pip and virtualenv
-  PIP_ROOT_USER_ACTION=ignore "${versioned_tool_path}/bin/python" \
+  PIP_ROOT_USER_ACTION=ignore PIP_USE_PEP517=true "${versioned_tool_path}/bin/python" \
     -W ignore \
     -m pip \
       install \
       --compile \
-      --use-pep517 \
       --no-warn-script-location \
       --no-cache-dir \
       --quiet \

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -198,6 +198,9 @@ RUN set -ex; \
 #--------------------------------------
 FROM build-rootless as testc
 
+# test older python install
+RUN install-tool python 3.6.15
+
 # needs to be v2
 RUN install-tool python 2.7.18
 


### PR DESCRIPTION
Older python (like 3.6.15) comes with an older `pip`, so the `--use-pep517` flag isn't supported.
We now use `PIP_USE_PEP517=true` env to force the flag, which is ignored by older `pip`.