### PR TITLE
feat(tools): add PDM to tools

### DIFF
--- a/src/usr/local/buildpack/tools/v2/pdm.sh
+++ b/src/usr/local/buildpack/tools/v2/pdm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+. "$(get_buildpack_path)/utils/python.sh"
+
+function link_tool () {
+  post_install
+  [[ -n $SKIP_VERSION ]] || poetry --version
+}

--- a/src/usr/local/buildpack/tools/v2/pdm.sh
+++ b/src/usr/local/buildpack/tools/v2/pdm.sh
@@ -5,5 +5,5 @@
 
 function link_tool () {
   post_install
-  [[ -n $SKIP_VERSION ]] || poetry --version
+  [[ -n $SKIP_VERSION ]] || pdm --version
 }

--- a/test/Dockerfile.jammy
+++ b/test/Dockerfile.jammy
@@ -137,6 +137,8 @@ RUN install-tool pipenv 2023.4.29
 RUN install-tool hashin 0.17.0
 # renovate: datasource=pypi
 RUN install-tool poetry 1.4.2
+# renovate: datasource=pypi
+RUN install-tool pdm 2.6.1
 
 #--------------------------------------
 # Image: test-ruby

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -200,10 +200,6 @@ FROM build as test-pdm
 
 USER 1000
 
-# make as latest
-# renovate: datasource=github-releases packageName=containerbase/python-prebuild
-RUN install-tool python 3.11.3
-
 # renovate: datasource=pypi
 RUN install-tool pdm 2.6.1
 

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -194,6 +194,20 @@ RUN set -ex; \
   pipenv lock;
 
 #--------------------------------------
+# test pdm: pdm (multiple python)
+#--------------------------------------
+FROM build as test-pdm
+
+USER 1000
+
+# make as latest
+# renovate: datasource=github-releases packageName=containerbase/python-prebuild
+RUN install-tool python 3.11.3
+
+# renovate: datasource=pypi
+RUN install-tool pdm 2.6.1
+
+#--------------------------------------
 # test c: python2.7
 #--------------------------------------
 FROM build-rootless as testc
@@ -232,6 +246,7 @@ COPY --from=test-poetry-d /.dummy /.dummy
 COPY --from=test-poetry-e /.dummy /.dummy
 COPY --from=test-pipenv-a /.dummy /.dummy
 COPY --from=test-pipenv-b /.dummy /.dummy
+COPY --from=test-pdm /.dummy /.dummy
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy

--- a/test/python/Dockerfile
+++ b/test/python/Dockerfile
@@ -94,7 +94,7 @@ FROM poetry as test-poetry-b
 
 RUN set -ex; cd c-poetry && poetry update --lock --no-interaction
 
-RUN set -ex; cd c-poetry && poetry add h3py
+RUN set -ex; cd c-poetry && poetry add h5py
 
 
 #--------------------------------------
@@ -160,7 +160,7 @@ RUN install-tool poetry 1.4.2
 RUN set -ex \
   && cd c-poetry \
   && poetry update --lock --no-interaction \
-  && poetry add h3py \
+  && poetry add h5py \
   ;
 
 # renovate: datasource=pypi


### PR DESCRIPTION
- Adds PDM for usage by the new PEP621 manager
- replaces h3py with h5py for tests as the former is no longer available 