### PR TITLE
fix: retry all errors when fetching dotnet install script

### DIFF
--- a/src/usr/local/buildpack/tools/v2/dotnet.sh
+++ b/src/usr/local/buildpack/tools/v2/dotnet.sh
@@ -54,7 +54,9 @@ function install_tool () {
     tool_path=$(find_tool_path)
   fi
 
-  curl --retry 3 -sSL https://dot.net/v1/dotnet-install.sh | bash -s - --install-dir "$tool_path" --no-path --version "$TOOL_VERSION" --skip-non-versioned-files
+  curl --retry 3 --retry-all-errors -sSLO https://dot.net/v1/dotnet-install.sh
+  bash dotnet-install.sh --install-dir "$tool_path" --no-path --version "$TOOL_VERSION" --skip-non-versioned-files
+  rm -f dotnet-install.sh
 
   # we need write access to some sub dirs for non root
   if [[ $(is_root) -eq 0 ]]; then


### PR DESCRIPTION
A potential fix for test failures downloading .NET[^1].

The `--retry` flag on its own only retries transient errors[^2]:

>If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up. Setting the number to 0 makes curl do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504 response code.

However, the error we see is not transient

```
curl: (52) Empty reply from server
```

`--retry-all-errors`[^3] is "the "sledgehammer" of retrying." It does come with the following warning:

>For server compatibility curl attempts to retry failed flaky transfers as close as possible to how they were started, but this is not possible with redirected input or output. For example, before retrying it removes output data from a failed partial transfer that was written to an output file. However this is not true of data redirected to a | pipe or > file, which are not reset. We strongly suggest you do not parse or record output via redirect in combination with this option, since you may receive duplicate data.

So I've changed our call to curl to output to a file, that is executed on the next line, instead of executing it directly.

[^1]: https://github.com/containerbase/base/actions/runs/4996425760/jobs/8949596008?pr=978
[^2]: https://curl.se/docs/manpage.html#--retry
[^3]: https://curl.se/docs/manpage.html#--retry-all-errors