### PR TITLE
chore: refactor devcontainer to remove warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,19 @@
 {
   "name": "containerbase",
   "dockerFile": "Dockerfile",
-  "settings": {
-    "terminal.integrated.shell.linux": "/bin/bash"
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
   },
-  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
   "postCreateCommand": "yarn install"
 }


### PR DESCRIPTION
The following changes have been made: 

- Use of properties `settings` and `extensions` at the top level has been deprecated and moved under [customizations](https://containers.dev/supporting).
- `terminal.integrated.shell.linux` has been deprecated in favor of `terminal.integrated.defaultProfile.linux`.