### PR TITLE
feat(node): enable use-openssl-ca

### DIFF
--- a/docs/custom-root-ca.md
+++ b/docs/custom-root-ca.md
@@ -13,9 +13,6 @@ FROM containerbase/base
 
 COPY my-root-ca.crt /usr/local/share/ca-certificates/my-root-ca.crt
 RUN update-ca-certificates
-
-# configure node
-ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/my-root-ca.crt
 ```
 
 ### Buildtime Java install
@@ -40,7 +37,6 @@ Most OpenSSL base tools (and maybe BoringSSL) support `SSL_CERT_FILE` environmen
 docker run --rm -it \
   -v my-root-ca.crt:/my-root-ca.crt \
   -e SSL_CERT_FILE=/my-root-ca.crt \
-  -e NODE_EXTRA_CA_CERTS=/my-root-ca.crt \
   containerbase/base bash
 ```
 
@@ -53,6 +49,5 @@ docker run --rm -it \
   -v my-root-ca.crt:/my-root-ca.crt \
   -v my-root-cert-store.jks:/opt/containerbase/ssl/cacerts \
   -e SSL_CERT_FILE=/my-root-ca.crt \
-  -e NODE_EXTRA_CA_CERTS=/my-root-ca.crt \
   containerbase/base bash
 ```

--- a/src/usr/local/containerbase/tools/v2/node.sh
+++ b/src/usr/local/containerbase/tools/v2/node.sh
@@ -106,7 +106,8 @@ function install_tool () {
   if [[ ${MAJOR} -lt 15 ]]; then
     echo "updating node-gyp"
     # update to latest node-gyp to fully support python3
-    PATH=${versioned_tool_path}/bin:$PATH npm explore npm -g --prefix "$versioned_tool_path" --silent -- "npm" install node-gyp@latest --no-audit --cache "${NPM_CONFIG_CACHE}" --silent 2>&1
+    PATH=${versioned_tool_path}/bin:$PATH NODE_OPTIONS=--use-openssl-ca \
+      npm explore npm -g --prefix "$versioned_tool_path" --silent -- "npm" install node-gyp@latest --no-audit --cache "${NPM_CONFIG_CACHE}" --silent 2>&1
   fi
 
   # clean temp dir
@@ -130,7 +131,7 @@ function link_tool () {
 
   tool_env=$(find_tool_env)
 
-  # if not root, set the npmprefix config option to the user folder
+  # if not root, set the npm prefix config option to the user folder
   cat >> "$tool_env" <<- EOM
 # openshift override unknown user home
 if [ "\${EUID}" != 0 ] && [ "\${EUID}" != ${USER_ID} ]; then
@@ -151,7 +152,7 @@ function post_install () {
   local versioned_tool_path
   versioned_tool_path=$(find_versioned_tool_path)
 
-  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin"
+  shell_wrapper "${TOOL_NAME}" "${versioned_tool_path}/bin" "NODE_OPTIONS=\"\$NODE_OPTIONS --use-openssl-ca\""
   shell_wrapper npm "${versioned_tool_path}/bin"
   shell_wrapper npx "${versioned_tool_path}/bin"
   if [[ -e "${versioned_tool_path}/bin/corepack" ]];then

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -92,6 +92,7 @@ RUN  set -ex \
 RUN set -ex; \
   nginx \
   && su -c 'curl -svo /dev/null https://buildkitsandbox' ${USER_NAME} \
+  && su -c 'node --use-openssl-ca request.mjs' ${USER_NAME} \
   && su -c 'php request.php' ${USER_NAME} \
   && pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }" \
   && su -c 'python request.py' ${USER_NAME} \

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -72,14 +72,15 @@ RUN set -ex; \
   openssl x509 -noout -text -in renovate.pem;
 
 RUN set -ex; \
-  nginx \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://localhost' ${USER_NAME} \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://buildkitsandbox' ${USER_NAME} \
-  && su -c 'NODE_EXTRA_CA_CERTS=/test/ca.pem node request.mjs' ${USER_NAME} \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem php request.php' ${USER_NAME} \
-  && SSL_CERT_FILE=/test/ca.pem pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }" \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem python request.py' ${USER_NAME} \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem ruby request.rb' ${USER_NAME} \
+  nginx; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://localhost' ${USER_NAME}; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://buildkitsandbox' ${USER_NAME}; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem node request.mjs' ${USER_NAME}; \
+  su -c 'NODE_EXTRA_CA_CERTS=/test/ca.pem node request.mjs' ${USER_NAME}; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem php request.php' ${USER_NAME}; \
+  SSL_CERT_FILE=/test/ca.pem pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem python request.py' ${USER_NAME}; \
+  su -c 'SSL_CERT_FILE=/test/ca.pem ruby request.rb' ${USER_NAME}; \
   true
 
 
@@ -90,13 +91,14 @@ RUN  set -ex \
 
 # use global root certs
 RUN set -ex; \
-  nginx \
-  && su -c 'curl -svo /dev/null https://buildkitsandbox' ${USER_NAME} \
-  && su -c 'node --use-openssl-ca request.mjs' ${USER_NAME} \
-  && su -c 'php request.php' ${USER_NAME} \
-  && pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }" \
-  && su -c 'python request.py' ${USER_NAME} \
-  && su -c 'ruby request.rb' ${USER_NAME} \
+  nginx; \
+  su -c 'curl -svo /dev/null https://buildkitsandbox' ${USER_NAME}; \
+  su -c 'node request.mjs' ${USER_NAME}; \
+  su -c 'npm_config_registry=https://localhost npm ping' ${USER_NAME}; \
+  su -c 'php request.php' ${USER_NAME}; \
+  pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"; \
+  su -c 'python request.py' ${USER_NAME}; \
+  su -c 'ruby request.rb' ${USER_NAME}; \
   true
 
 

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -44,9 +44,28 @@ RUN set -ex; \
 
 
 #--------------------------------------
-# test: curl
+# test: custom root ca
 #--------------------------------------
 FROM build as testa
+
+# renovate: datasource=node
+RUN install-tool node v18.17.0
+
+# renovate: datasource=github-releases packageName=containerbase/python-prebuild
+RUN install-tool php 7.4.14
+RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/php") -eq ${USER_ID} ]
+
+# renovate: datasource=github-releases packageName=PowerShell/PowerShell
+RUN install-tool powershell v7.3.6
+
+# renovate: datasource=github-releases depName=python packageName=containerbase/python-prebuild
+ARG PYTHON_VERSION=3.11.4
+RUN install-tool python
+RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/python") -eq ${USER_ID} ]
+
+# Do not renovate ruby 2.x
+RUN install-tool ruby 2.6.4
+RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/ruby") -eq ${USER_ID} ]
 
 RUN set -ex; \
   openssl x509 -noout -text -in ca.pem; \
@@ -55,7 +74,14 @@ RUN set -ex; \
 RUN set -ex; \
   nginx \
   && su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://localhost' ${USER_NAME} \
-  && su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://buildkitsandbox' ${USER_NAME}
+  && su -c 'SSL_CERT_FILE=/test/ca.pem curl -svo /dev/null https://buildkitsandbox' ${USER_NAME} \
+  && su -c 'NODE_EXTRA_CA_CERTS=/test/ca.pem node request.mjs' ${USER_NAME} \
+  && su -c 'SSL_CERT_FILE=/test/ca.pem php request.php' ${USER_NAME} \
+  && SSL_CERT_FILE=/test/ca.pem pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }" \
+  && su -c 'SSL_CERT_FILE=/test/ca.pem python request.py' ${USER_NAME} \
+  && su -c 'SSL_CERT_FILE=/test/ca.pem ruby request.rb' ${USER_NAME} \
+  true
+
 
 # install root ca
 RUN  set -ex \
@@ -65,106 +91,18 @@ RUN  set -ex \
 # use global root certs
 RUN set -ex; \
   nginx \
-  && su -c 'curl -svo /dev/null https://buildkitsandbox' ${USER_NAME}
+  && su -c 'curl -svo /dev/null https://buildkitsandbox' ${USER_NAME} \
+  && su -c 'php request.php' ${USER_NAME} \
+  && pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }" \
+  && su -c 'python request.py' ${USER_NAME} \
+  && su -c 'ruby request.rb' ${USER_NAME} \
+  true
 
-#--------------------------------------
-# test: python
-#--------------------------------------
-FROM build as testb
-
-# renovate: datasource=github-releases depName=python packageName=containerbase/python-prebuild
-ARG PYTHON_VERSION=3.11.4
-RUN install-tool python
-
-RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/python") -eq ${USER_ID} ]
-
-RUN set -ex; \
-  nginx && su -c 'SSL_CERT_FILE=/test/ca.pem python request.py' ${USER_NAME}
-
-# install root ca
-RUN  set -ex \
-  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
-  && update-ca-certificates
-
-RUN set -ex; \
-  nginx && su -c 'python request.py' ${USER_NAME}
-
-#--------------------------------------
-# test: node
-#--------------------------------------
-FROM build as testc
-
-# renovate: datasource=node
-RUN install-tool node v18.17.0
-
-RUN set -ex; \
-  nginx && su -c 'NODE_EXTRA_CA_CERTS=/test/ca.pem node request.mjs' ${USER_NAME}
-
-#--------------------------------------
-# test: php
-#--------------------------------------
-FROM build as testd
-
-# renovate: datasource=github-releases packageName=containerbase/python-prebuild
-RUN install-tool php 7.4.14
-
-RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/php") -eq ${USER_ID} ]
-
-RUN set -ex; \
-  nginx && su -c 'SSL_CERT_FILE=/test/ca.pem php request.php' ${USER_NAME}
-
-# install root ca
-RUN  set -ex \
-  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
-  && update-ca-certificates
-
-RUN set -ex; \
-  nginx && su -c 'php request.php' ${USER_NAME}
-
-#--------------------------------------
-# test: ruby
-#--------------------------------------
-FROM build as teste
-
-# Do not renovate ruby 2.x
-RUN install-tool ruby 2.6.4
-
-RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/ruby") -eq ${USER_ID} ]
-
-RUN set -ex; \
-  nginx && su -c 'SSL_CERT_FILE=/test/ca.pem ruby request.rb' ${USER_NAME}
-
-# install root ca
-RUN  set -ex \
-  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
-  && update-ca-certificates
-
-RUN set -ex; \
-  nginx && su -c 'ruby request.rb' ${USER_NAME}
-
-#--------------------------------------
-# test: powershell
-#--------------------------------------
-FROM build as testf
-
-# renovate: datasource=github-releases packageName=PowerShell/PowerShell
-RUN install-tool powershell v7.3.6
-
-RUN set -ex; cat /etc/hosts; \
-  nginx && SSL_CERT_FILE=/test/ca.pem pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"
-
-# install root ca
-RUN  set -ex \
-  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
-  && update-ca-certificates
-
-RUN set -ex; \
-  nginx && pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"
 
 #--------------------------------------
 # test: terraform
 #--------------------------------------
-FROM ubuntu:focal as testg
+FROM ubuntu:focal as testb
 
 ARG USER_NAME=terraform
 ARG USER_ID=1005
@@ -202,7 +140,7 @@ RUN mkdir $HOME/.tf-cache && TF_PLUGIN_CACHE_DIR=$HOME/.tf-cache terraform init
 #--------------------------------------
 # test: ignore tools
 #--------------------------------------
-FROM build as testh
+FROM build as testc
 
 RUN prepare-tool docker
 
@@ -232,7 +170,7 @@ RUN install-tool docker v24.0.5
 #--------------------------------------
 # test: bin path has 775
 #--------------------------------------
-FROM base as testi
+FROM base as testd
 
 RUN [ $(stat --format '%a' "/usr/local/bin") -eq 775 ]
 
@@ -243,7 +181,7 @@ RUN set -ex; [ -d /usr/local/erlang ] && echo "works" || exit 1;
 #--------------------------------------
 # test: vendir, helmfile, kustomize
 #--------------------------------------
-FROM base as testj
+FROM base as teste
 
 # renovate: datasource=github-releases packageName=vmware-tanzu/carvel-vendir
 ARG VENDIR_VERSION=0.32.2
@@ -293,8 +231,3 @@ COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
 COPY --from=testd /.dummy /.dummy
 COPY --from=teste /.dummy /.dummy
-COPY --from=testf /.dummy /.dummy
-COPY --from=testg /.dummy /.dummy
-COPY --from=testh /.dummy /.dummy
-COPY --from=testi /.dummy /.dummy
-COPY --from=testj /.dummy /.dummy

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -81,6 +81,14 @@ RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/python") -eq ${USER_ID} ]
 RUN set -ex; \
   nginx && su -c 'SSL_CERT_FILE=/test/ca.pem python request.py' ${USER_NAME}
 
+# install root ca
+RUN  set -ex \
+  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
+  && update-ca-certificates
+
+RUN set -ex; \
+  nginx && su -c 'python request.py' ${USER_NAME}
+
 #--------------------------------------
 # test: node
 #--------------------------------------
@@ -105,6 +113,13 @@ RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/php") -eq ${USER_ID} ]
 RUN set -ex; \
   nginx && su -c 'SSL_CERT_FILE=/test/ca.pem php request.php' ${USER_NAME}
 
+# install root ca
+RUN  set -ex \
+  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
+  && update-ca-certificates
+
+RUN set -ex; \
+  nginx && su -c 'php request.php' ${USER_NAME}
 
 #--------------------------------------
 # test: ruby
@@ -119,6 +134,13 @@ RUN set -ex; [ $(stat --format '%u' "/usr/local/bin/ruby") -eq ${USER_ID} ]
 RUN set -ex; \
   nginx && su -c 'SSL_CERT_FILE=/test/ca.pem ruby request.rb' ${USER_NAME}
 
+# install root ca
+RUN  set -ex \
+  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
+  && update-ca-certificates
+
+RUN set -ex; \
+  nginx && su -c 'ruby request.rb' ${USER_NAME}
 
 #--------------------------------------
 # test: powershell
@@ -130,6 +152,14 @@ RUN install-tool powershell v7.3.6
 
 RUN set -ex; cat /etc/hosts; \
   nginx && SSL_CERT_FILE=/test/ca.pem pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"
+
+# install root ca
+RUN  set -ex \
+  && cp ca.pem /usr/local/share/ca-certificates/renovate-ca.crt \
+  && update-ca-certificates
+
+RUN set -ex; \
+  nginx && pwsh -c "&{ \$ErrorActionPreference='Stop'; invoke-webrequest https://buildkitsandbox }"
 
 #--------------------------------------
 # test: terraform

--- a/test/latest/src/etc/nginx/sites-enabled/default
+++ b/test/latest/src/etc/nginx/sites-enabled/default
@@ -16,6 +16,11 @@ server {
 
   server_name _;
 
+  location /-/ping {
+    default_type application/json;
+    return 200 "{}";
+  }
+
   location / {
     try_files $uri $uri/ =404;
   }

--- a/tools/esbuild.js
+++ b/tools/esbuild.js
@@ -45,6 +45,8 @@ await exec([
   '--out-path',
   './src/usr/local/containerbase/bin',
   '--public',
+  '--options',
+  'use-openssl-ca',
   // '--debug',
   'dist',
 ]);


### PR DESCRIPTION
Using `NODE_EXTRA_CA_CERTS` is no longer required.

Using `NODE_OPTIONS=--use-openssl-ca` is known to be broken on Node `>=18.0.0 <18.5.0`[^1]

[^1]: https://nodejs.org/en/blog/vulnerability/july-2022-security-releases#openssl---aes-ocb-fails-to-encrypt-some-bytes-mediumcve-2022-2097