### PR TITLE
feat(node): drop renovate re2 mirror on newer versions

### DIFF
--- a/src/cli/tools/node/index.ts
+++ b/src/cli/tools/node/index.ts
@@ -132,7 +132,7 @@ export class InstallNodeService extends InstallNodeBaseService {
       const tmp = await fs.mkdtemp(
         join(this.pathSvc.tmpDir, 'containerbase-npm-'),
       );
-      const env = this.prepareEnv(tmp);
+      const env = this.prepareEnv(version, tmp);
       env.PATH = `${path}/bin:${penv.PATH}`;
       env.NODE_OPTIONS = '--use-openssl-ca';
       // update to latest node-gyp to fully support python3

--- a/src/cli/tools/node/npm.ts
+++ b/src/cli/tools/node/npm.ts
@@ -1,5 +1,6 @@
 import { execa } from 'execa';
 import { injectable } from 'inversify';
+import { satisfies } from 'semver';
 import { InstallNpmBaseService } from './utils';
 
 @injectable()
@@ -10,12 +11,15 @@ export class InstallRenovateService extends InstallNpmBaseService {
     return ['--no-optional', 're2'];
   }
 
-  override prepareEnv(tmp: string): NodeJS.ProcessEnv {
-    const env = super.prepareEnv(tmp);
-    env.RE2_DOWNLOAD_MIRROR = this.envSvc.replaceUrl(
-      'https://github.com/containerbase/node-re2-prebuild/releases/download',
-    );
-    env.RE2_DOWNLOAD_SKIP_PATH = '1';
+  override prepareEnv(version: string, tmp: string): NodeJS.ProcessEnv {
+    const env = super.prepareEnv(version, tmp);
+
+    if (satisfies(version, '<37.234.0')) {
+      env.RE2_DOWNLOAD_MIRROR = this.envSvc.replaceUrl(
+        'https://github.com/containerbase/node-re2-prebuild/releases/download',
+      );
+      env.RE2_DOWNLOAD_SKIP_PATH = '1';
+    }
     return env;
   }
 }

--- a/src/cli/tools/node/utils.ts
+++ b/src/cli/tools/node/utils.ts
@@ -21,7 +21,7 @@ export abstract class InstallNodeBaseService extends InstallToolBaseService {
     super(pathSvc, envSvc);
   }
 
-  protected prepareEnv(tmp: string): NodeJS.ProcessEnv {
+  protected prepareEnv(_version: string, tmp: string): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {
       NO_UPDATE_NOTIFIER: '1',
       npm_config_update_notifier: 'false',
@@ -86,7 +86,7 @@ export abstract class InstallNpmBaseService extends InstallNodeBaseService {
     const tmp = await fs.mkdtemp(
       join(this.pathSvc.tmpDir, 'containerbase-npm-'),
     );
-    const env = this.prepareEnv(tmp);
+    const env = this.prepareEnv(version, tmp);
 
     // TODO: create recursive
     if (!(await this.pathSvc.findToolPath(this.name))) {


### PR DESCRIPTION
- https://github.com/renovatebot/renovate/releases/tag/37.234.0
- re2 now has official linux arm64 support