### PR TITLE
feat(node): support yarn v2+

### DIFF
--- a/src/cli/install-tool/index.ts
+++ b/src/cli/install-tool/index.ts
@@ -12,6 +12,7 @@ import { InstallMavenService } from '../tools/java/maven';
 import { InstallNodeService } from '../tools/node';
 import {
   InstallRenovateService,
+  InstallYarnService,
   InstallYarnSlimService,
 } from '../tools/node/npm';
 import {
@@ -51,6 +52,7 @@ function prepareInstallContainer(): Container {
   container.bind(INSTALL_TOOL_TOKEN).to(InstallMavenService);
   container.bind(INSTALL_TOOL_TOKEN).to(InstallNodeService);
   container.bind(INSTALL_TOOL_TOKEN).to(InstallRenovateService);
+  container.bind(INSTALL_TOOL_TOKEN).to(InstallYarnService);
   container.bind(INSTALL_TOOL_TOKEN).to(InstallYarnSlimService);
 
   logger.trace('preparing install container done');

--- a/src/cli/tools/index.ts
+++ b/src/cli/tools/index.ts
@@ -28,7 +28,6 @@ export const ResolverMap: Record<string, InstallToolType | undefined> = {
   corepack: 'npm',
   npm: 'npm',
   pnpm: 'npm',
-  yarn: 'npm',
 };
 
 /**

--- a/src/cli/tools/node/npm.ts
+++ b/src/cli/tools/node/npm.ts
@@ -1,6 +1,7 @@
 import { execa } from 'execa';
 import { injectable } from 'inversify';
 import { satisfies } from 'semver';
+import { logger, parse } from '../../utils';
 import { InstallNpmBaseService } from './utils';
 
 @injectable()
@@ -25,10 +26,28 @@ export class InstallRenovateService extends InstallNpmBaseService {
 }
 
 @injectable()
+export class InstallYarnService extends InstallNpmBaseService {
+  override readonly name: string = 'yarn';
+
+  protected override tool(version: string): string {
+    const ver = parse(version);
+    if (ver.major >= 2) {
+      logger.debug({ version }, 'Using yarnpkg/cli-dist');
+      return '@yarnpkg/cli-dist';
+    }
+    return this.name;
+  }
+
+  override async test(): Promise<void> {
+    await execa(this.name, ['--version'], { stdio: 'inherit' });
+  }
+}
+
+@injectable()
 export class InstallYarnSlimService extends InstallNpmBaseService {
   override readonly name: string = 'yarn-slim';
 
-  protected override get tool(): string {
+  protected override tool(): string {
     return 'yarn';
   }
 

--- a/src/cli/tools/node/utils.ts
+++ b/src/cli/tools/node/utils.ts
@@ -76,7 +76,7 @@ export abstract class InstallNodeBaseService extends InstallToolBaseService {
 
 @injectable()
 export abstract class InstallNpmBaseService extends InstallNodeBaseService {
-  protected get tool(): string {
+  protected tool(_version: string): string {
     return this.name;
   }
 
@@ -107,7 +107,7 @@ export abstract class InstallNpmBaseService extends InstallNodeBaseService {
       npm,
       [
         'install',
-        `${this.tool}@${version}`,
+        `${this.tool(version)}@${version}`,
         '--save-exact',
         '--no-audit',
         '--prefix',
@@ -169,7 +169,10 @@ export abstract class InstallNpmBaseService extends InstallNodeBaseService {
     }
 
     if (is.string(pkg.bin)) {
-      await this.shellwrapper({ srcDir: src, name: pkg.name ?? this.tool });
+      await this.shellwrapper({
+        srcDir: src,
+        name: pkg.name ?? this.tool(version),
+      });
       return;
     }
 
@@ -178,8 +181,8 @@ export abstract class InstallNpmBaseService extends InstallNodeBaseService {
     }
   }
 
-  override async test(_version: string): Promise<void> {
-    await execa(this.tool, ['--version'], { stdio: 'inherit' });
+  override async test(version: string): Promise<void> {
+    await execa(this.tool(version), ['--version'], { stdio: 'inherit' });
   }
 
   override async validate(version: string): Promise<boolean> {
@@ -212,7 +215,7 @@ export abstract class InstallNpmBaseService extends InstallNodeBaseService {
       this.pathSvc.versionedToolPath(this.name, version),
       node,
       'node_modules',
-      this.tool,
+      this.tool(version),
       'package.json',
     );
   }

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -89,6 +89,11 @@ RUN set -ex; \
   [ "$(command -v yarn)" = "/usr/local/bin/yarn" ] && echo "works" || exit 1; \
   yarn --version
 
+RUN install-tool yarn 2.4.2
+RUN install-tool yarn 3.8.1
+
+# renovate: datasource=npm packageName=@yarnpkg/cli-dist
+RUN install-tool yarn 4.1.0
 
 #--------------------------------------
 # test: pnpm
@@ -494,20 +499,20 @@ RUN set -ex; \
 #--------------------------------------
 FROM base
 
-COPY --from=testa /.dummy /.dummy
+# COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
-COPY --from=testc /.dummy /.dummy
-COPY --from=testd /.dummy /.dummy
-COPY --from=teste /.dummy /.dummy
-COPY --from=testf /.dummy /.dummy
-COPY --from=testg /.dummy /.dummy
-COPY --from=testh /.dummy /.dummy
-COPY --from=testi /.dummy /.dummy
-COPY --from=testj /.dummy /.dummy
-COPY --from=testk /.dummy /.dummy
-COPY --from=testl /.dummy /.dummy
-COPY --from=testm /.dummy /.dummy
-COPY --from=testn /.dummy /.dummy
-COPY --from=testo /.dummy /.dummy
-COPY --from=testp /.dummy /.dummy
-COPY --from=testq /.dummy /.dummy
+# COPY --from=testc /.dummy /.dummy
+# COPY --from=testd /.dummy /.dummy
+# COPY --from=teste /.dummy /.dummy
+# COPY --from=testf /.dummy /.dummy
+# COPY --from=testg /.dummy /.dummy
+# COPY --from=testh /.dummy /.dummy
+# COPY --from=testi /.dummy /.dummy
+# COPY --from=testj /.dummy /.dummy
+# COPY --from=testk /.dummy /.dummy
+# COPY --from=testl /.dummy /.dummy
+# COPY --from=testm /.dummy /.dummy
+# COPY --from=testn /.dummy /.dummy
+# COPY --from=testo /.dummy /.dummy
+# COPY --from=testp /.dummy /.dummy
+# COPY --from=testq /.dummy /.dummy


### PR DESCRIPTION
Allow installing yarn v2+ via `install-tool yarn <version>`.
We're using `@yarnpkg/cli-dist` for those versions.
Some older versions are missing there, so hopefully nobody will use those because renovate is using `@yarnpkg/cli` which has a lot more versions but is slower to install because it's not bundled.

- https://www.npmjs.com/package/@yarnpkg/cli-dist?activeTab=versions
- https://www.npmjs.com/package/@yarnpkg/cli?activeTab=versions