### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - jammy
@@ -190,6 +191,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         tag:
           - dart


### PR DESCRIPTION
The matrix tests are very flaky sometimes, so don't cancel other's for faster retries