### PR TITLE
fix: add support for Elixir v1.17.0

### DIFF
--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -10,12 +10,10 @@ function install_tool () {
 
   # https://github.com/elixir-lang/elixir/releases/tag/v1.14.0
   # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
-  if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -eq 14 ]; then
-    base_file=elixir-otp-23.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
+  if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
     base_file=elixir-otp-27.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 15 ]; then
-    base_file=elixir-otp-26.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 14 ]; then
+    base_file=elixir-otp-25.zip
   fi
 
   file=$(get_from_url "${base_url}/v${TOOL_VERSION}/${base_file}")

--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -11,7 +11,7 @@ function install_tool () {
   # https://github.com/elixir-lang/elixir/releases/tag/v1.14.0
   # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
-    base_file=elixir-otp-27.zip
+    base_file=elixir-otp-25.zip
   elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 15 ]; then
     base_file=elixir-otp-24.zip
   elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -eq 14 ]; then

--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -14,7 +14,7 @@ function install_tool () {
     base_file=elixir-otp-23.zip
   elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
     base_file=elixir-otp-27.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 16 ]; then
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 15 ]; then
     base_file=elixir-otp-26.zip
   fi
 

--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -12,8 +12,10 @@ function install_tool () {
   # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
     base_file=elixir-otp-27.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 14 ]; then
-    base_file=elixir-otp-25.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 15 ]; then
+    base_file=elixir-otp-24.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -eq 14 ]; then
+    base_file=elixir-otp-23.zip
   fi
 
   file=$(get_from_url "${base_url}/v${TOOL_VERSION}/${base_file}")

--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -12,10 +12,10 @@ function install_tool () {
   # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -eq 14 ]; then
     base_file=elixir-otp-23.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -le 16 ]; then
-    base_file=elixir-otp-26.zip
   elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
     base_file=elixir-otp-27.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 16 ]; then
+    base_file=elixir-otp-26.zip
   fi
 
   file=$(get_from_url "${base_url}/v${TOOL_VERSION}/${base_file}")

--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -8,12 +8,14 @@ function install_tool () {
 
   check_command erl
 
-
   # https://github.com/elixir-lang/elixir/releases/tag/v1.14.0
+  # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   if [ "$MAJOR" -eq 1 ] && [ "$MINOR" -eq 14 ]; then
     base_file=elixir-otp-23.zip
-  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -gt 14 ]; then
-    base_file=elixir-otp-24.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -le 16 ]; then
+    base_file=elixir-otp-26.zip
+  elif [ "$MAJOR" -eq 1 ] && [ "$MINOR" -ge 17 ]; then
+    base_file=elixir-otp-27.zip
   fi
 
   file=$(get_from_url "${base_url}/v${TOOL_VERSION}/${base_file}")


### PR DESCRIPTION
Elixir v1.17.0 just released. The install script is failing because the OTP version if/else block isn't up-to-date.

Renovate is effectively broken for Elixir right now: https://github.com/sheerlox/elixir_renovate_demo/pull/6

Renovate log from the PR above (Mend Renovate job id `7e88e954-625d-4a07-804b-45eefc1a151c`):
```
[17:27:45.046] INFO (193): Installing tool elixir@1.17.0...
installing v2 tool elixir v1.17.0
Download failed: https://github.com/elixir-lang/elixir/releases/download/v1.17.0/elixir-otp-24.zip
[17:27:45.616] INFO (221): Downloading file ...
    url: "https://github.com/elixir-lang/elixir/releases/download/v1.17.0/elixir-otp-24.zip"
    output: "/tmp/renovate/cache/containerbase/f7649696d9e36012fd17fe14a3344673897f8c089328bc8a15abaf579e0f5ab1/elixir-otp-24.zip"
[17:27:45.764] FATAL (221): Response code 404 (Not Found)
    err: {
      "type": "HTTPError",
      "message": "Response code 404 (Not Found)",
      // ...
    }
[17:27:45.890] INFO (221): Download completed with errors  in 281ms.
[17:27:45.901] FATAL (193): Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh elixir 1.17.0
    err: {
      "type": "Error",
      "message": "Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh elixir 1.17.0",
      "stack":
          Error: Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh elixir 1.17.0
              at makeError (/snapshot/dist/containerbase-cli.js:39455:13)
              at handlePromise (/snapshot/dist/containerbase-cli.js:40170:29)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async InstallLegacyToolService.execute (/snapshot/dist/containerbase-cli.js:56573:5)
              at async InstallToolService.execute (/snapshot/dist/containerbase-cli.js:56765:9)
              at async InstallToolShortCommand.execute (/snapshot/dist/containerbase-cli.js:57006:14)
              at async InstallToolShortCommand.validateAndExecute (/snapshot/dist/containerbase-cli.js:2428:26)
              at async _Cli.run (/snapshot/dist/containerbase-cli.js:3541:22)
              at async _Cli.runExit (/snapshot/dist/containerbase-cli.js:3549:28)
              at async main (/snapshot/dist/containerbase-cli.js:57200:3)
      "shortMessage": "Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh elixir 1.17.0",
      "command": "/usr/local/containerbase/bin/install-tool.sh elixir 1.17.0",
      "escapedCommand": "\\"/usr/local/containerbase/bin/install-tool.sh\\" elixir 1.17.0",
      "exitCode": 1,
      "cwd": "/tmp/renovate/repos/github/sheerlox/elixir_renovate_demo",
      "failed": true,
      "timedOut": false,
      "isCanceled": false,
      "killed": false
    }
[17:27:46.150] INFO (193): Installed tool elixir with errors in 1.1s.
```