### PR TITLE
feat(golang): pick patch version automatically

### DIFF
--- a/test/golang/Dockerfile
+++ b/test/golang/Dockerfile
@@ -104,6 +104,17 @@ RUN set -ex; \
   [ "$(command -v mod)" = "/usr/local/bin/mod" ] && echo "works" || exit 1;
 
 #--------------------------------------
+# test: golang (automatic patch version selection)
+#--------------------------------------
+FROM base AS testd
+
+# do not update
+RUN install-tool golang 1.20
+
+# go 1.20 is EOL so the latest patch version should stay at 1.20.14
+RUN go version | grep "go1.20.14"
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM base
@@ -111,3 +122,4 @@ FROM base
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
+COPY --from=testd /.dummy /.dummy


### PR DESCRIPTION
Currently, it is required to specify the full go version `install-tool golang 1.22.5`.

With this change, the patch version can be left out:  `install-tool golang 1.22` and the latest available patch version will be installed.


A test was added to ensure "1.20" will resolve to "1.20.14". As "1.20" is end of life, there should be no further patches and therefore the test should not break. I guess there is a small chance that the go team decides to patch "1.20", if a serious vulnerability is discovered. It's unlikely, as the EOL date is already several months ago.