### PR TITLE
fix(nix): update path to hydra build for 2.24 and newer

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -357,9 +357,12 @@ Nix releases are downloaded from:
 
 The second url will be used soon (#2066).
 
+Starting with `2.24`, the Hydra job name is `buildStatic.nix.${arch}`, instead of `buildStatic.${arch}`.
+
 Samples:
 
 ```txt
+https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.nix.x86_64-linux/latest/download-by-type/file/binary-dist
 https://hydra.nixos.org/job/nix/maintenance-2.4/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist
 https://releases.nixos.org/nix/nix-2.2/nix-2.2-aarch64-linux.tar.bz2
 https://releases.nixos.org/nix/nix-2.2/nix-2.2-aarch64-linux.tar.bz2.sha256

--- a/src/usr/local/containerbase/tools/v2/nix.sh
+++ b/src/usr/local/containerbase/tools/v2/nix.sh
@@ -18,7 +18,7 @@ function install_tool() {
 
   arch=$(uname -m)
 
-  if [[ ${MAJOR} -eq 2 && ${MINOR} -lt 24 ]]; then
+  if [[ ${MAJOR} -lt 2 || (${MAJOR} -eq 2 && ${MINOR} -lt 24) ]]; then
     build_path="buildStatic.${arch}-linux"
   else
     build_path="buildStatic.nix.${arch}-linux"

--- a/src/usr/local/containerbase/tools/v2/nix.sh
+++ b/src/usr/local/containerbase/tools/v2/nix.sh
@@ -9,6 +9,7 @@ function install_tool() {
   local versioned_tool_path
   local file
   local arch
+  local build_path
 
   # if [[ ${MAJOR} -lt 2 || (${MAJOR} -eq 2 && ${MINOR} -lt 14) ]]; then
   #   echo "Nix version ${TOOL_VERSION} is not supported! Use v2.14 or higher." >&2
@@ -16,7 +17,14 @@ function install_tool() {
   # fi
 
   arch=$(uname -m)
-  file=$(get_from_url "https://hydra.nixos.org/job/nix/maintenance-${TOOL_VERSION}/buildStatic.${arch}-linux/latest/download-by-type/file/binary-dist")
+
+  if [[ ${MAJOR} -eq 2 && ${MINOR} -lt 24 ]]; then
+    build_path="buildStatic.${arch}-linux"
+  else
+    build_path="buildStatic.nix.${arch}-linux"
+  fi
+
+  file=$(get_from_url "https://hydra.nixos.org/job/nix/maintenance-${TOOL_VERSION}/${build_path}/latest/download-by-type/file/binary-dist")
 
   versioned_tool_path=$(create_versioned_tool_path)
   create_folder "${versioned_tool_path}/bin"


### PR DESCRIPTION
Renovate currently fails to download Nix because the URL for the latest version has been updated.

```
WARN: Error updating flake.lock (branch="renovate/lock-file-maintenance")
{
  "err": {
    "cmd": "/bin/sh -c install-tool nix 2.24.1",
    "stderr": "",
    "stdout": "installing v2 tool nix v2.24\n[12:53:34.669] INFO (53): Installing tool nix@2.24.1...\nDownload failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist\nDownload failed, retrying\nDownload failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist\nDownload failed, retrying\nDownload failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist\nDownload failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist\n[12:53:37.663] INFO (103): Downloading file ...\n    url: \"https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist\"\n    output: \"/tmp/renovate/cache/containerbase/50789f3416da6a7a362045e5add6d2ba81fef302b1678eae91ab63978e430317/binary-dist\"\n[12:53:38.117] ERROR (103): Response code 404 (Not Found)\n[12:53:38.118] FATAL (103): Download failed in 454ms.\n[12:53:38.296] ERROR (53): Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh nix 2.24.1\n[12:53:38.297] FATAL (53): Install tool nix failed in 3.6s.\n",
```

Changes:

- Bumped the version of Nix used in tests to the latest. This replicates the issue.
- Updated the Hydra URL for Nix v2.24+.
- Made a note in the registry docs about the URL change.