### PR TITLE
fix(nix): Fix install script for version > 2.23

### DIFF
--- a/src/usr/local/containerbase/tools/v2/nix.sh
+++ b/src/usr/local/containerbase/tools/v2/nix.sh
@@ -15,8 +15,12 @@ function install_tool() {
   #   exit 1
   # fi
 
+  if [[ (${MAJOR} -eq 2 && ${MINOR} -gt 23) || ${MAJOR} -gt 2 ]]; then
+    suffix=".nix"
+  fi
+
   arch=$(uname -m)
-  file=$(get_from_url "https://hydra.nixos.org/job/nix/maintenance-${TOOL_VERSION}/buildStatic.${arch}-linux/latest/download-by-type/file/binary-dist")
+  file=$(get_from_url "https://hydra.nixos.org/job/nix/maintenance-${TOOL_VERSION}/buildStatic${suffix}.${arch}-linux/latest/download-by-type/file/binary-dist")
 
   versioned_tool_path=$(create_versioned_tool_path)
   create_folder "${versioned_tool_path}/bin"


### PR DESCRIPTION
Starting with nix 2.24, the binary is located under `buildStatic.nix.x86_64-linux` instead of `buildStatic.x86_64-linux`.

Without this commit:

```
ubuntu@125e8aa7e907:/$ install-tool nix 2.24
installing v2 tool nix v2.24
[13:40:49.461] INFO (87): Installing tool nix@2.24...
Download failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist
Download failed, retrying
Download failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist
Download failed, retrying
Download failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist
Download failed: https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist
[13:40:52.311] INFO (137): Downloading file ...
    url: "https://hydra.nixos.org/job/nix/maintenance-2.24/buildStatic.x86_64-linux/latest/download-by-type/file/binary-dist"
    output: "/tmp/50789f3416da6a7a362045e5add6d2ba81fef302b1678eae91ab63978e430317/binary-dist"
[13:40:52.589] ERROR (137): 
[13:40:52.590] FATAL (137): Download failed in 278ms.
[13:40:52.653] ERROR (87): Command failed with exit code 1: /usr/local/containerbase/bin/install-tool.sh nix 2.24
[13:40:52.653] FATAL (87): Install tool nix failed in 3.1s.
```

With this commit:

```
ubuntu@51abd3626c1e:/$ install-tool nix 2.24
installing v2 tool nix v2.24
[13:47:18.920] INFO (5): Installing tool nix@2.24...
linking tool nix v2.24
nix (Nix) 2.24.1
[13:47:26.446] INFO (5): Install tool nix succeeded in 7.5s.
```