### PR TITLE
fix(git): use modern apt config

### DIFF
--- a/src/usr/local/containerbase/tools/git.sh
+++ b/src/usr/local/containerbase/tools/git.sh
@@ -4,10 +4,13 @@ require_root
 
 version_codename=$(get_distro)
 
-echo "deb http://ppa.launchpad.net/git-core/ppa/ubuntu ${version_codename} main" | tee /etc/apt/sources.list.d/git.list
-curl --retry 3 -sSL \
-  'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE1DD270288B4E6030699E45FA1715D88E1DF1F24' \
-  | apt-key add -
+install -m 0755 -d /etc/apt/keyrings
+curl --retry 3 -fsSL -o /etc/apt/keyrings/git.asc \
+  'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF911AB184317630C59970973E363C90F8F1B6217'
+chmod a+r /etc/apt/keyrings/git.asc
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/git.asc] http://ppa.launchpad.net/git-core/ppa/ubuntu ${version_codename} main" | tee /etc/apt/sources.list.d/git.list
+
 
 # TODO: Only latest version available on launchpad :-/
 #apt_install git=1:${TOOL_VERSION}*


### PR DESCRIPTION
New additional signing key since 2024-04

https://launchpad.net/~git-core/+archive/ubuntu/ppa?field.series_filter=focal