### PR TITLE
fix(dotnet): use new cdn url

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -104,13 +104,13 @@ https://download.docker.com/linux/static/stable/aarch64/docker-24.0.5.tgz
 
 Dotnet releases are downloaded from:
 
-- `https://dotnetcli.azureedge.net/dotnet/Sdk`
+- `https://builds.dotnet.microsoft.com/dotnet/Sdk`
 
 Samples:
 
 ```txt
-https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz
-https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz
+https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz
+https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-arm64.tar.gz
 ```
 
 ## `erlang`

--- a/src/cli/tools/dotnet.ts
+++ b/src/cli/tools/dotnet.ts
@@ -117,8 +117,9 @@ export class DotnetInstallService extends BaseInstallService {
   override async install(version: string): Promise<void> {
     const toolPath = this.pathSvc.toolPath(this.name);
 
-    //  https://dotnetcli.azureedge.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz
-    const url = `https://dotnetcli.azureedge.net/dotnet/Sdk/${version}/dotnet-sdk-${version}-linux-${this.arch}.tar.gz`;
+    // https://github.com/dotnet/core/issues/9671
+    // https://builds.dotnet.microsoft.com/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz
+    const url = `https://builds.dotnet.microsoft.com/dotnet/Sdk/${version}/dotnet-sdk-${version}-linux-${this.arch}.tar.gz`;
     const file = await this.http.download({ url });
 
     await this.compress.extract({

--- a/test/dotnet/Dockerfile
+++ b/test/dotnet/Dockerfile
@@ -69,9 +69,6 @@ RUN set -ex;  \
 #--------------------------------------
 FROM base AS testb
 
-# Do not change
-RUN install-tool dotnet 6.0.416
-
 # renovate: datasource=dotnet packageName=dotnet-sdk
 RUN install-tool dotnet 8.0.404
 
@@ -122,8 +119,8 @@ FROM build AS testd
 
 # only patch updates
 # renovate: datasource=dotnet packageName=dotnet-sdk
-RUN install-tool dotnet 8.0.404
-RUN set -ex; dotnet --version | grep 8.0.
+RUN install-tool dotnet 9.0.101
+RUN set -ex; dotnet --version | grep 9.0.
 
 RUN set -ex; \
     dotnet restore --use-lock-file
@@ -140,5 +137,4 @@ FROM base
 COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
-# TODO: enable for net 9.0
-# COPY --from=testd /.dummy /.dummy
+COPY --from=testd /.dummy /.dummy


### PR DESCRIPTION
This is probably a breaking change for url replacement users. 🤷‍♂️ 

- Closes #3866