### PR TITLE
fix(node): use `NODE_OPTIONS` for `--use-openssl-ca`

### DIFF
--- a/src/cli/tools/node/index.ts
+++ b/src/cli/tools/node/index.ts
@@ -36,6 +36,7 @@ export class NodePrepareService extends BasePrepareService {
         NO_UPDATE_NOTIFIER: '1',
         npm_config_update_notifier: 'false',
         npm_config_fund: 'false',
+        NODE_OPTIONS: '--use-openssl-ca',
       });
     }
   }
@@ -131,7 +132,6 @@ export class NodeInstallService extends NodeBaseInstallService {
       );
       const env = this.prepareEnv(version, tmp);
       env.PATH = `${path}/bin:${penv.PATH}`;
-      env.NODE_OPTIONS = '--use-openssl-ca';
       // update to latest node-gyp to fully support python3
       await this.updateNodeGyp(path, tmp, env, true);
       await fs.rm(tmp, { recursive: true, force: true });
@@ -150,10 +150,7 @@ export class NodeInstallService extends NodeBaseInstallService {
   override async postInstall(version: string): Promise<void> {
     const src = join(this.pathSvc.versionedToolPath(this.name, version), 'bin');
 
-    await this.shellwrapper({
-      srcDir: src,
-      args: '--use-openssl-ca',
-    });
+    await this.shellwrapper({ srcDir: src });
     await this.shellwrapper({ srcDir: src, name: 'npm' });
     await this.shellwrapper({ srcDir: src, name: 'npx' });
 

--- a/src/cli/tools/node/utils.ts
+++ b/src/cli/tools/node/utils.ts
@@ -26,6 +26,7 @@ export abstract class NodeBaseInstallService extends BaseInstallService {
       NO_UPDATE_NOTIFIER: '1',
       npm_config_update_notifier: 'false',
       npm_config_fund: 'false',
+      NODE_OPTIONS: penv.NODE_OPTIONS ?? '--use-openssl-ca',
     };
 
     if (!penv.npm_config_cache && !penv.NPM_CONFIG_CACHE) {
@@ -34,7 +35,7 @@ export abstract class NodeBaseInstallService extends BaseInstallService {
 
     const registry = this.envSvc.replaceUrl(
       defaultRegistry,
-      isNonEmptyStringAndNotWhitespace(env.CONTAINERBASE_CDN_NPM),
+      isNonEmptyStringAndNotWhitespace(penv.CONTAINERBASE_CDN_NPM),
     );
     if (registry !== defaultRegistry) {
       env.npm_config_registry = registry;


### PR DESCRIPTION
Pass  `--use-openssl-ca` via `NODE_OPTIONS`, which can be overridden from outer env.

I'm not sure, but `NODE_OPTIONS` can maybe no longer set via renovate options. 🤔 

- closes #4033
