### PR TITLE
fix(poetry): check plugins when resolving poetry version

### DIFF
--- a/src/cli/install-tool/index.ts
+++ b/src/cli/install-tool/index.ts
@@ -52,6 +52,7 @@ import {
   ConanVersionResolver,
 } from '../tools/python/conan';
 import { PipVersionResolver } from '../tools/python/pip';
+import { PoetryVersionResolver } from '../tools/python/poetry';
 import { PipBaseInstallService } from '../tools/python/utils';
 import {
   CocoapodsInstallService,
@@ -136,6 +137,7 @@ function prepareResolveContainer(): Container {
   container.bind(TOOL_VERSION_RESOLVER).to(MavenVersionResolver);
   container.bind(TOOL_VERSION_RESOLVER).to(NodeVersionResolver);
   container.bind(TOOL_VERSION_RESOLVER).to(PhpVersionResolver);
+  container.bind(TOOL_VERSION_RESOLVER).to(PoetryVersionResolver);
   container.bind(TOOL_VERSION_RESOLVER).to(YarnVersionResolver);
 
   logger.trace('preparing container done');

--- a/src/cli/tools/python/pip.ts
+++ b/src/cli/tools/python/pip.ts
@@ -6,14 +6,18 @@ import { PypiJson } from './schema';
 export abstract class PipVersionResolver extends ToolVersionResolver {
   async resolve(version: string | undefined): Promise<string | undefined> {
     if (version === undefined || version === 'latest') {
-      const meta = PypiJson.parse(
-        await this.http.getJson(
-          `https://pypi.org/pypi/${normalizePythonDepName(this.tool)}/json`,
-        ),
-      );
+      const meta = await this.fetchMeta(this.tool);
       return meta.info.version;
     }
     return version;
+  }
+
+  protected async fetchMeta(tool: string): Promise<PypiJson> {
+    return PypiJson.parse(
+      await this.http.getJson(
+        `https://pypi.org/pypi/${normalizePythonDepName(tool)}/json`,
+      ),
+    );
   }
 }
 

--- a/src/cli/tools/python/poetry.ts
+++ b/src/cli/tools/python/poetry.ts
@@ -1,0 +1,33 @@
+import { maxSatisfying } from '@renovatebot/pep440';
+import { injectable } from 'inversify';
+import { logger } from '../../utils';
+import { PipVersionResolver } from './pip';
+
+@injectable()
+export class PoetryVersionResolver extends PipVersionResolver {
+  override tool = 'poetry';
+
+  override async resolve(
+    version: string | undefined,
+  ): Promise<string | undefined> {
+    if (version === undefined || version === 'latest') {
+      const mirrorMeta = await this.fetchMeta('poetry-plugin-pypi-mirror');
+      logger.debug({ info: mirrorMeta.info }, 'poetry-plugin-pypi-mirror');
+
+      const poetryVersion = mirrorMeta.info.requires_dist?.poetry;
+
+      if (!poetryVersion) {
+        throw new Error('poetry-plugin-pypi-mirror has missing poetry version');
+      }
+
+      const meta = await this.fetchMeta(this.tool);
+      const version = maxSatisfying(
+        Object.keys(meta.releases).filter((v) => !meta.releases[v]!.yanked),
+        poetryVersion,
+      );
+      logger.debug({ version }, 'Resolved poetry version');
+      return version ?? meta.info.version;
+    }
+    return version;
+  }
+}

--- a/src/cli/tools/python/schema.ts
+++ b/src/cli/tools/python/schema.ts
@@ -1,7 +1,37 @@
 import { z } from 'zod';
+import { logger } from '../../utils';
+
+// function fixPythonVersion(version: string): string {
+//   return version; //.replace('\u003C', '<').replace('\u003E', '>');
+// }
+
+const depRe = /^(?<name>[a-z-]+)(?<extra>\[[a-z,]+\])?(?<version>.+)(?:$|;)/;
+
+function parseDep(dep: string): [string, string] | null {
+  const groups = depRe.exec(dep)?.groups;
+  if (!groups) {
+    logger.debug({ dep }, 'Failed to parse dependency');
+    return null;
+  }
+  return [groups.name!, groups.version!];
+}
+
+const PypiRelease = z.object({
+  packagetype: z.enum(['sdist', 'bdist_wheel', 'unknown']).catch('unknown'),
+  requires_python: z.string().nullish(),
+  yanked: z.boolean(),
+});
 
 export const PypiJson = z.object({
   info: z.object({
     version: z.string(),
+    requires_python: z.string().nullish(),
+    requires_dist: z
+      .array(z.string().transform(parseDep))
+      .transform((v) => Object.fromEntries(v.filter((d) => !!d)))
+      .nullish(),
   }),
+  releases: z.record(z.array(PypiRelease).transform((v) => v[0])),
 });
+
+export type PypiJson = z.infer<typeof PypiJson>;


### PR DESCRIPTION
Fixes recent ci errors, because `poetry-plugin-pypi-mirror` isn't compatibe with `poetry>=2.1.0`.

next step is to respect the python dependency.