### PR TITLE
feat(haskel): support cabal v1 and v2

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -334,6 +334,8 @@ Cabal releases are downloaded from:
 Samples:
 
 ```txt
+https://downloads.haskell.org/~cabal/cabal-install-1.24.0.2/cabal-install-1.24.0.2-x86_64-unknown-linux.tar.gz
+https://downloads.haskell.org/~cabal/cabal-install-2.4.1.0/cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz
 https://downloads.haskell.org/~cabal/cabal-install-3.16.1.0/cabal-install-3.16.1.0-aarch64-linux-deb10.tar.xz
 https://downloads.haskell.org/~cabal/cabal-install-3.16.1.0/cabal-install-3.16.1.0-x86_64-linux-deb10.tar.xz
 https://downloads.haskell.org/~cabal/cabal-install-3.16.1.0/SHA256SUMS

--- a/src/cli/tools/haskell/cabal.ts
+++ b/src/cli/tools/haskell/cabal.ts
@@ -26,23 +26,43 @@ export class CabalInstallService extends BaseInstallService {
   }
 
   override async install(version: string): Promise<void> {
+    const major = parseInt(version.split('.').at(0)!);
     const baseUrl = `https://downloads.haskell.org/~cabal/cabal-install-${version}/`;
-    // use static deb10 binary as it is compatible with all supported ubuntu versions
-    const filename = `cabal-install-${version}-${this.arch}-linux-deb10.tar.xz`;
 
-    const checksumFile = await this.http.download({
-      url: `${baseUrl}SHA256SUMS`,
-    });
-    const expectedChecksum = (await fs.readFile(checksumFile, 'utf-8'))
-      .split('\n')
-      .find((l) => l.includes(filename))
-      ?.split(' ')[0];
+    let file: string;
+    const strip = major < 2 ? 7 : 0;
 
-    const file = await this.http.download({
-      url: `${baseUrl}${filename}`,
-      checksumType: 'sha256',
-      expectedChecksum,
-    });
+    if (major < 3) {
+      if (this.arch !== 'x86_64') {
+        throw new Error(
+          `Unsupported architecture ${this.envSvc.arch} for cabal-install versions < 3.0. Only x86_64 is supported.`,
+        );
+      }
+      const filename =
+        major < 2
+          ? `cabal-install-${version}-${this.arch}-unknown-linux.tar.gz`
+          : `cabal-install-${version}-${this.arch}-unknown-linux.tar.xz`;
+
+      file = await this.http.download({
+        url: `${baseUrl}${filename}`,
+      });
+    } else {
+      // use static deb10 binary as it is compatible with all supported ubuntu versions
+      const filename = `cabal-install-${version}-${this.arch}-linux-deb10.tar.xz`;
+      const checksumFile = await this.http.download({
+        url: `${baseUrl}SHA256SUMS`,
+      });
+      const expectedChecksum = (await fs.readFile(checksumFile, 'utf-8'))
+        .split('\n')
+        .find((l) => l.includes(filename))
+        ?.split(' ')[0];
+
+      file = await this.http.download({
+        url: `${baseUrl}${filename}`,
+        checksumType: 'sha256',
+        expectedChecksum,
+      });
+    }
 
     await this.pathSvc.ensureToolPath(this.name);
 
@@ -54,6 +74,7 @@ export class CabalInstallService extends BaseInstallService {
     await this.compress.extract({
       file,
       cwd: path,
+      strip,
     });
   }
 

--- a/src/cli/tools/haskell/ghc.ts
+++ b/src/cli/tools/haskell/ghc.ts
@@ -25,9 +25,20 @@ export class GhcInstallService extends BaseInstallService {
   }
 
   override async install(version: string): Promise<void> {
+    const major = parseInt(version.split('.').at(0)!);
     const baseUrl = `https://downloads.haskell.org/~ghc/${version}/`;
+
     // use static deb10 binary as it is compatible with all supported ubuntu versions
-    const filename = `ghc-${version}-${this.arch}-deb10-linux.tar.xz`;
+    let filename = `ghc-${version}-${this.arch}-deb10-linux.tar.xz`;
+
+    if (major < 9) {
+      if (this.arch !== 'x86_64') {
+        throw new Error(
+          `Unsupported architecture ${this.envSvc.arch} for ghc versions < 9.0. Only x86_64 is supported.`,
+        );
+      }
+      filename = `ghc-${version}-${this.arch}-deb9-linux.tar.xz`;
+    }
 
     const checksumFile = await this.http.download({
       url: `${baseUrl}SHA256SUMS`,

--- a/test/haskell/Dockerfile
+++ b/test/haskell/Dockerfile
@@ -43,13 +43,22 @@ FROM base AS build
 RUN prepare-tool cabal ghc
 
 #--------------------------------------
-# test: haskell (root,open-shift)
+# test-ghc
 #--------------------------------------
-FROM base AS haskell-a
+FROM build AS test-ghc
 
-RUN env
 # renovate: datasource=docker packageName=haskell
 RUN install-tool ghc 9.14.1
+
+RUN set -ex; \
+  ghc --version; \
+  ghc-pkg dot --global; \
+  true;
+
+#--------------------------------------
+# test: haskell (root,open-shift)
+#--------------------------------------
+FROM test-ghc AS haskell-a
 
 # renovate: datasource=github-releases packageName=haskell/cabal versioning=docker
 RUN install-tool cabal 3.16.1.0
@@ -98,9 +107,48 @@ RUN set -ex; \
     true
 
 #--------------------------------------
+# test: cabal v1 (root,open-shift)
+#--------------------------------------
+FROM test-ghc AS cabal-v1
+
+# renovate: datasource=github-releases packageName=haskell/cabal versioning=docker
+RUN install-tool cabal 1.24.0.2
+
+
+USER 1001
+
+RUN set -ex; \
+  cabal --version; \
+  cabal sandbox init; \
+  true;
+#--------------------------------------
+# test: cabal v2 (root,open-shift)
+#--------------------------------------
+FROM test-ghc AS cabal-v2
+
+# cabal v2 need ghc <8.7
+# no binaries yet
+# RUN install-tool ghc 8.8.4
+
+# renovate: datasource=github-releases packageName=haskell/cabal versioning=docker
+RUN install-tool cabal 2.4.1.0
+
+
+USER 1001
+
+RUN set -ex; \
+  cabal --version; \
+  cabal sandbox init; \
+  true;
+
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM base
 
-COPY --from=haskell-a /.dummy /.dummy
-COPY --from=haskell-b /.dummy /.dummy
+COPY --from=test-ghc /.dummy /.dummy
+# COPY --from=haskell-a /.dummy /.dummy
+# COPY --from=haskell-b /.dummy /.dummy
+COPY --from=cabal-v1 /.dummy /.dummy
+COPY --from=cabal-v2 /.dummy /.dummy


### PR DESCRIPTION
cabal v1 and v2 need an older ghc (compiler) which isn't available 

- closes #5808