### PR TITLE
fix(rust): add support for `nightly` channel

### DIFF
--- a/src/usr/local/containerbase/tools/v2/rust.sh
+++ b/src/usr/local/containerbase/tools/v2/rust.sh
@@ -24,7 +24,7 @@ function init_tool () {
 }
 
 function check_tool_requirements () {
-  if [[ "${TOOL_VERSION}" == "nightly" || "${TOOL_VERSION}" == "beta" ]]; then
+  if [[ "${TOOL_VERSION}" == "beta" || "${TOOL_VERSION}" == "nightly" || "${TOOL_VERSION}" == nightly-* ]]; then
     # allow beta and nightly versions
     return
   fi
@@ -43,6 +43,10 @@ function install_tool () {
   local file_name
 
   file_name="rust-${TOOL_VERSION}-${arch}-unknown-linux-gnu.tar"
+  if [[ "${TOOL_VERSION}" == nightly-* ]]; then
+    NIGHTLY_DATE="${TOOL_VERSION#nightly-}"
+    file_name="${NIGHTLY_DATE}/rust-nightly-${arch}-unknown-linux-gnu.tar"
+  fi
   base_url="https://static.rust-lang.org/dist/${file_name}"
 
   # not all releases have checksums

--- a/test/rust/Dockerfile
+++ b/test/rust/Dockerfile
@@ -117,6 +117,19 @@ RUN rustc --version
 RUN cargo --version
 
 #--------------------------------------
+# test e: nightly with date
+#--------------------------------------
+FROM base AS teste
+
+USER 12021
+
+RUN install-tool rust nightly-2026-06-19
+
+SHELL [ "/bin/sh", "-c" ]
+RUN rustc --version
+RUN cargo --version
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM base
@@ -125,3 +138,4 @@ COPY --from=testa /.dummy /.dummy
 COPY --from=testb /.dummy /.dummy
 COPY --from=testc /.dummy /.dummy
 COPY --from=testd /.dummy /.dummy
+COPY --from=teste /.dummy /.dummy


### PR DESCRIPTION
As per https://github.com/renovatebot/renovate/discussions/43489, when
Renovate provides a date-based nightly version, such as
`nightly-2026-06-19`, Containerbase doesn't currently determine the
correct URL to download the nightly build from.

We can make sure to rewrite the URL as appropriate when a specific
Nightly version is specified.

With help from Claude to write the test, and GPT-4.1 to write the
pattern match.

