### PR TITLE
feat(erlang): use OTP 27 by default for Elixir 1.20

### DIFF
--- a/src/usr/local/containerbase/tools/v2/elixir.sh
+++ b/src/usr/local/containerbase/tools/v2/elixir.sh
@@ -35,7 +35,7 @@ function install_tool () {
   local versioned_tool_path
   local file
   local base_url="https://github.com/elixir-lang/elixir/releases/download"
-  local base_file=elixir-otp-26.zip
+  local base_file=elixir-otp-27.zip
 
   check_command erl
 
@@ -49,6 +49,8 @@ function install_tool () {
     base_file=elixir-otp-24.zip
   elif dpkg --compare-versions "${TOOL_VERSION}" lt 1.19.0; then
     base_file=elixir-otp-25.zip
+  elif dpkg --compare-versions "${TOOL_VERSION}" lt 1.20.0; then
+    base_file=elixir-otp-26.zip
   fi
 
   file=$(get_from_url "${base_url}/v${TOOL_VERSION}/${base_file}")


### PR DESCRIPTION
This should make https://github.com/containerbase/base/pull/6850 happy

As of 1.20 Elixir does not support OTP 26 anymore so that should not be the default choice here.

https://elixir.hexdocs.pm/1.20.1/compatibility-and-deprecations.html#between-elixir-and-erlang-otp

I see renovate jobs failing because when installing Elixir 1.20 they fail to download elixir-otp-26.zip from the releases. See assets here for example: https://github.com/elixir-lang/elixir/releases/tag/v1.20-latest

NOTE: this PR is like https://github.com/containerbase/base/pull/6880 but with verified commits.
