### PR TITLE
feat: add apm (Agent Package Manager) install support

### DIFF
--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -44,6 +44,21 @@ https://github.com/chainguard-dev/apko/releases/download/v0.30.11/apko_0.30.11_l
 https://github.com/chainguard-dev/apko/releases/download/v0.30.11/checksums.txt
 ```
 
+## `apm`
+
+APM (Agent Package Manager) releases are downloaded from:
+
+- `https://github.com/microsoft/apm/releases`
+
+Samples:
+
+```txt
+https://github.com/microsoft/apm/releases/download/v0.24.0/apm-linux-x86_64.tar.gz
+https://github.com/microsoft/apm/releases/download/v0.24.0/apm-linux-x86_64.tar.gz.sha256
+https://github.com/microsoft/apm/releases/download/v0.24.0/apm-linux-arm64.tar.gz
+https://github.com/microsoft/apm/releases/download/v0.24.0/apm-linux-arm64.tar.gz.sha256
+```
+
 ## `bazelisk`
 
 Bazelisk releases are downloaded from:

--- a/src/cli/install-tool/index.ts
+++ b/src/cli/install-tool/index.ts
@@ -8,6 +8,7 @@ import {
   createContainer,
 } from '../services/index.ts';
 import { ApkoInstallService } from '../tools/apko.ts';
+import { ApmInstallService } from '../tools/apm.ts';
 import { BazeliskInstallService } from '../tools/bazelisk.ts';
 import { BufInstallService } from '../tools/buf.ts';
 import { BunInstallService } from '../tools/bun.ts';
@@ -134,6 +135,7 @@ async function prepareInstallContainer(): Promise<Container> {
   // modern tool services
   container.bind(INSTALL_TOOL_TOKEN).to(AndroidSdkCmdlineToolsInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(ApkoInstallService);
+  container.bind(INSTALL_TOOL_TOKEN).to(ApmInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(ComposerInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(BazeliskInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(BuildxInstallService);

--- a/src/cli/tools/apm.ts
+++ b/src/cli/tools/apm.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs/promises';
+import { injectFromHierarchy, injectable } from 'inversify';
+import { BaseInstallService } from '../install-tool/base-install.service.ts';
+
+@injectable()
+@injectFromHierarchy()
+export class ApmInstallService extends BaseInstallService {
+  readonly name = 'apm';
+
+  private get ghArch(): string {
+    switch (this.envSvc.arch) {
+      case 'arm64':
+        return 'arm64';
+      case 'amd64':
+        return 'x86_64';
+    }
+  }
+
+  override async install(version: string): Promise<void> {
+    /**
+     * APM (Agent Package Manager) ships self-contained PyInstaller `onedir`
+     * bundles (an `apm` binary next to an `_internal` directory) as
+     * `apm-<os>-<arch>.tar.gz` release assets, each accompanied by a
+     * `.sha256` sidecar.
+     * @see {@link https://github.com/microsoft/apm/releases}
+     */
+    const baseUrl = `https://github.com/microsoft/apm/releases/download/v${version}/`;
+    const filename = `apm-linux-${this.ghArch}.tar.gz`;
+    const url = `${baseUrl}${filename}`;
+
+    const checksumFile = await this.http.download({ url: `${url}.sha256` });
+    const expectedChecksum = (await fs.readFile(checksumFile, 'utf-8'))
+      .split('\n')
+      .find((l) => l.includes(filename))
+      ?.split(/\s+/)[0];
+
+    const file = await this.http.download({
+      url,
+      checksumType: 'sha256',
+      expectedChecksum,
+    });
+
+    await this.pathSvc.ensureToolPath(this.name);
+
+    const path = await this.pathSvc.createVersionedToolPath(this.name, version);
+    // strip the top-level `apm-linux-<arch>` directory so the `apm` binary and
+    // its sibling `_internal` bundle end up directly in the versioned path.
+    await this.compress.extract({ file, cwd: path, strip: 1 });
+  }
+
+  override async link(version: string): Promise<void> {
+    const src = this.pathSvc.versionedToolPath(this.name, version);
+    await this.shellwrapper({ srcDir: src });
+  }
+
+  override async test(_version: string): Promise<void> {
+    await this._spawn(this.name, ['--version']);
+  }
+}

--- a/src/cli/tools/index.ts
+++ b/src/cli/tools/index.ts
@@ -3,6 +3,7 @@ import type { InstallToolType } from '../utils';
 export const NoPrepareTools = [
   'android-sdk-cmdline-tools',
   'apko',
+  'apm',
   'bazelisk',
   'bower',
   'buf',

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -212,7 +212,7 @@ RUN prepare-tool all
 RUN set -ex; [ -d /usr/local/erlang ] && echo "works" || exit 1;
 
 #--------------------------------------
-# test: bazelisk, buf, bun, deno, devbox, helmfile, kustomize, skopeo, tofu, vendir
+# test: apm, bazelisk, buf, bun, deno, devbox, helmfile, kustomize, skopeo, tofu, vendir
 #--------------------------------------
 FROM base AS teste
 
@@ -230,6 +230,9 @@ RUN install-tool deno 2.9.1
 
 # renovate: datasource=github-releases packageName=chainguard-dev/apko
 RUN install-tool apko 1.2.22
+
+# renovate: datasource=github-releases packageName=microsoft/apm
+RUN install-tool apm 0.24.0
 
 # renovate: datasource=github-releases packageName=jetify-com/devbox
 RUN install-tool devbox 0.17.5

--- a/test/latest/Dockerfile.arm64
+++ b/test/latest/Dockerfile.arm64
@@ -65,6 +65,14 @@ FROM base AS test-apko
 RUN install-tool apko 1.2.22
 
 #--------------------------------------
+# Image: apm
+#--------------------------------------
+FROM base AS test-apm
+
+# renovate: datasource=github-releases packageName=microsoft/apm
+RUN install-tool apm 0.24.0
+
+#--------------------------------------
 # Image: devbox
 #--------------------------------------
 FROM base AS test-devbox
@@ -206,6 +214,7 @@ COPY --from=test-bazelisk /.dummy /.dummy
 COPY --from=test-bun /.dummy /.dummy
 COPY --from=test-deno /.dummy /.dummy
 COPY --from=test-apko /.dummy /.dummy
+COPY --from=test-apm /.dummy /.dummy
 COPY --from=test-devbox /.dummy /.dummy
 COPY --from=test-docker /.dummy /.dummy
 COPY --from=test-git /.dummy /.dummy


### PR DESCRIPTION
## Description

Adds `install-tool apm` support for [APM (Agent Package Manager)](https://github.com/microsoft/apm) — a language-agnostic dependency manager for AI-agent context (`apm.yml` / `apm.lock.yaml`).

This is a prerequisite for adding APM support to Renovate (see renovatebot/renovate discussion [#42507](https://github.com/renovatebot/renovate/discussions/42507) and PR [#44390](https://github.com/renovatebot/renovate/pull/44390)): Renovate needs the `apm` CLI available in its container image to regenerate the lock file after updating dependency refs.

## How it works

APM publishes self-contained native binaries on its GitHub releases as `apm-linux-<arch>.tar.gz` (with a `.sha256` sidecar per asset). Each archive is a PyInstaller `onedir` bundle — an `apm` executable next to an `_internal/` directory — wrapped in a top-level `apm-linux-<arch>/` folder.

The new `ApmInstallService` (modeled on the existing `deno`/`bun` single-binary tools):

- downloads the arch-specific tarball (`amd64` → `x86_64`, `arm64` → `arm64`);
- verifies the published `.sha256` checksum;
- extracts with `strip: 1` so the `apm` binary and its sibling `_internal/` land directly in the versioned tool path (keeping them adjacent, as the PyInstaller bootloader requires);
- shell-wraps the `apm` binary onto `PATH`;
- validates the install via `apm --version`.

## Changes

- `src/cli/tools/apm.ts` — new `ApmInstallService`.
- `src/cli/install-tool/index.ts` — register the service in the DI container.
- `src/cli/tools/index.ts` — add `apm` to `NoPrepareTools` (self-contained binary; no prepare/init step).
- `test/latest/Dockerfile` — add an `install-tool apm` e2e check with a `renovate:` annotation (`datasource=github-releases packageName=microsoft/apm`).

## Testing

- `prettier`, `eslint`, and `tsc` pass on the changed files.
- Existing unit tests pass, including the DI container spec (`src/cli/install-tool/index.spec.ts`).
- The Docker e2e install is wired into the `latest` test image and will exercise a real download/extract/link on both `x86_64` and `aarch64` in CI.