### PR TITLE
feat(tool): add nub package manager

### DIFF
--- a/src/cli/install-tool/index.ts
+++ b/src/cli/install-tool/index.ts
@@ -68,6 +68,7 @@ import { MiseInstallService, MiseVersionResolver } from '../tools/mise.ts';
 import { NixInstallService } from '../tools/nix.ts';
 import { NodeInstallService } from '../tools/node/index.ts';
 import {
+  NubInstallService,
   RenovateInstallService,
   YarnInstallService,
   YarnSlimInstallService,
@@ -171,6 +172,7 @@ async function prepareInstallContainer(): Promise<Container> {
   container.bind(INSTALL_TOOL_TOKEN).to(NixInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(NugetInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(NodeInstallService);
+  container.bind(INSTALL_TOOL_TOKEN).to(NubInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(PaketInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(PhpInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(PixiInstallService);

--- a/src/cli/tools/index.ts
+++ b/src/cli/tools/index.ts
@@ -33,6 +33,7 @@ export const NoPrepareTools = [
   'nix',
   'nuget',
   'npm',
+  'nub',
   'paket',
   'pdm',
   'pip-tools',

--- a/src/cli/tools/node/npm.ts
+++ b/src/cli/tools/node/npm.ts
@@ -31,10 +31,6 @@ export class NubInstallService extends NpmBaseInstallService {
   protected override tool(): string {
     return '@nubjs/nub';
   }
-
-  override async test(): Promise<void> {
-    await this._spawn(this.name, ['--version']);
-  }
 }
 
 @injectable()

--- a/src/cli/tools/node/npm.ts
+++ b/src/cli/tools/node/npm.ts
@@ -22,6 +22,23 @@ export class RenovateInstallService extends NpmBaseInstallService {
 
 @injectable()
 @injectFromHierarchy()
+export class NubInstallService extends NpmBaseInstallService {
+  override readonly name: string = 'nub';
+
+  // The tool is `nub`, but it ships on npm under the scoped package
+  // `@nubjs/nub` (with per-platform binary optionalDependencies), so the
+  // install target differs from the tool name.
+  protected override tool(): string {
+    return '@nubjs/nub';
+  }
+
+  override async test(): Promise<void> {
+    await this._spawn(this.name, ['--version']);
+  }
+}
+
+@injectable()
+@injectFromHierarchy()
 export class YarnInstallService extends NpmBaseInstallService {
   override readonly name: string = 'yarn';
 


### PR DESCRIPTION
Adds a `nub` tool.

Nub is a Node package manager published as [`@nubjs/nub`](https://www.npmjs.com/package/@nubjs/nub) on npm. This lets Containerbase provision it the same way it provisions the other Node package managers, so a runtime using the default `binarySource=install` can install nub to run lockfile updates.

## Implementation

`NubInstallService` extends `NpmBaseInstallService` and overrides `tool()` to return `@nubjs/nub` — the tool name (`nub`) differs from the npm package, the same shape as `YarnInstallService` returning `@yarnpkg/cli-dist` for Yarn berry. It installs via `npm install @nubjs/nub@<version>` and is added to `NoPrepareTools`.

Scripts run on install (no `--ignore-scripts`): `@nubjs/nub`'s `postinstall` selects and places the per-platform binary from its `@nubjs/nub-<platform>` optional dependencies (glibc and musl variants for linux-x64 and linux-arm64), so the tool is usable after install.

## Context

Related: renovatebot/renovate#44422 — the companion Renovate manager PR (`nub` package-manager manager) that depends on this tool for its default `binarySource=install` runtime.

## AI assistance disclosure

This change was written with substantive assistance from an AI coding agent (Claude).
