### PR TITLE
feat: support installing Yarn 6 binaries

### DIFF
--- a/src/cli/tools/node/npm.ts
+++ b/src/cli/tools/node/npm.ts
@@ -27,6 +27,11 @@ export class YarnInstallService extends NpmBaseInstallService {
 
   protected override tool(version: string): string {
     const ver = parse(version);
+    if (ver.major >= 6) {
+      const arch = this.envSvc.arch === 'arm64' ? 'aarch64' : 'x86_64';
+      logger.debug({ version, arch }, 'Using native yarn package');
+      return `@yarnpkg/yarn-${arch}-unknown-linux-musl`;
+    }
     if (ver.major >= 2) {
       logger.debug({ version }, 'Using yarnpkg/cli-dist');
       return '@yarnpkg/cli-dist';

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -95,6 +95,11 @@ RUN install-tool yarn 3.8.1
 # renovate: datasource=npm packageName=@yarnpkg/cli-dist
 RUN install-tool yarn 4.17.1
 
+# renovate: datasource=npm packageName=@yarnpkg/yarn-x86_64-unknown-linux-musl
+RUN install-tool yarn 6.0.0-rc.19
+
+RUN test "$(yarn --version)" = "6.0.0-rc.19"
+
 #--------------------------------------
 # test: pnpm
 #--------------------------------------

--- a/test/node/Dockerfile
+++ b/test/node/Dockerfile
@@ -96,9 +96,11 @@ RUN install-tool yarn 3.8.1
 RUN install-tool yarn 4.17.1
 
 # renovate: datasource=npm packageName=@yarnpkg/yarn-x86_64-unknown-linux-musl
-RUN install-tool yarn 6.0.0-rc.19
+ARG YARN_VERSION=6.0.0-rc.19
 
-RUN test "$(yarn --version)" = "6.0.0-rc.19"
+RUN install-tool yarn "${YARN_VERSION}"
+
+RUN test "$(yarn --version)" = "${YARN_VERSION}"
 
 #--------------------------------------
 # test: pnpm

--- a/test/node/Dockerfile.arm64
+++ b/test/node/Dockerfile.arm64
@@ -57,6 +57,11 @@ FROM test-node AS test-yarn
 # renovate: datasource=npm
 RUN install-tool yarn 1.22.22
 
+# renovate: datasource=npm packageName=@yarnpkg/yarn-aarch64-unknown-linux-musl
+RUN install-tool yarn 6.0.0-rc.19
+
+RUN test "$(yarn --version)" = "6.0.0-rc.19"
+
 #--------------------------------------
 # Image: renovate
 #--------------------------------------

--- a/test/node/Dockerfile.arm64
+++ b/test/node/Dockerfile.arm64
@@ -58,9 +58,11 @@ FROM test-node AS test-yarn
 RUN install-tool yarn 1.22.22
 
 # renovate: datasource=npm packageName=@yarnpkg/yarn-aarch64-unknown-linux-musl
-RUN install-tool yarn 6.0.0-rc.19
+ARG YARN_VERSION=6.0.0-rc.19
 
-RUN test "$(yarn --version)" = "6.0.0-rc.19"
+RUN install-tool yarn "${YARN_VERSION}"
+
+RUN test "$(yarn --version)" = "${YARN_VERSION}"
 
 #--------------------------------------
 # Image: renovate


### PR DESCRIPTION
Supports Yarn v6, which ships as native binaries.

Resolves this issue https://github.com/renovatebot/renovate/discussions/44616