### PR TITLE
feat(tools): install Vite+ releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -105,6 +105,7 @@
         "tofu",
         "uv",
         "vendir",
+        "vp",
         "wally",
         "yarn"
       ],
@@ -160,6 +161,7 @@
         "tofu",
         "uv",
         "vendir",
+        "vp",
         "wally",
         "yarn"
       ],

--- a/docs/custom-registries.md
+++ b/docs/custom-registries.md
@@ -776,6 +776,20 @@ Samples:
 https://github.com/vmware-tanzu/carvel-vendir/releases/download/v0.22.0/vendir-linux-amd64
 ```
 
+## `vp`
+
+Vite+ releases are downloaded from:
+
+- `https://github.com/voidzero-dev/vite-plus/releases`
+
+Release archives and their checksum manifest follow these paths:
+
+```txt
+https://github.com/voidzero-dev/vite-plus/releases/download/v<version>/vp-x86_64-unknown-linux-gnu.tar.gz
+https://github.com/voidzero-dev/vite-plus/releases/download/v<version>/vp-aarch64-unknown-linux-gnu.tar.gz
+https://github.com/voidzero-dev/vite-plus/releases/download/v<version>/vp-checksums.txt
+```
+
 ## `wally`
 
 Wally releases are downloaded from:

--- a/src/cli/install-tool/index.ts
+++ b/src/cli/install-tool/index.ts
@@ -111,6 +111,7 @@ import { SwiftInstallService } from '../tools/swift.ts';
 import { TerraformInstallService } from '../tools/terraform.ts';
 import { TofuInstallService } from '../tools/tofu.ts';
 import { VendirInstallService } from '../tools/vendir.ts';
+import { VpInstallService } from '../tools/vp.ts';
 import { WallyInstallService } from '../tools/wally.ts';
 import { type InstallToolType, logger } from '../utils/index.ts';
 import { isNotKnownV2Tool } from '../utils/v2-tool.ts';
@@ -192,6 +193,7 @@ async function prepareInstallContainer(): Promise<Container> {
   container.bind(INSTALL_TOOL_TOKEN).to(TerraformInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(TofuInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(VendirInstallService);
+  container.bind(INSTALL_TOOL_TOKEN).to(VpInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(WallyInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(YarnInstallService);
   container.bind(INSTALL_TOOL_TOKEN).to(YarnSlimInstallService);

--- a/src/cli/tools/index.ts
+++ b/src/cli/tools/index.ts
@@ -51,6 +51,7 @@ export const NoPrepareTools = [
   'tofu',
   'uv',
   'vendir',
+  'vp',
   'wally',
   'yarn',
   'yarn-slim',

--- a/src/cli/tools/vp.spec.ts
+++ b/src/cli/tools/vp.spec.ts
@@ -1,0 +1,142 @@
+import fs from 'node:fs/promises';
+import { arch } from 'node:os';
+import { join } from 'node:path';
+import type { Container } from 'inversify';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  CompressionService,
+  HttpService,
+  LinkToolService,
+} from '../services/index.ts';
+import {
+  VP_SYNC_VERSIONS_UNAVAILABLE,
+  VpInstallService,
+  parseVitePlusChecksum,
+  vitePlusAssetName,
+} from './vp.ts';
+import { testContainer } from '~test/di.ts';
+import { ensurePaths } from '~test/path.ts';
+
+vi.mock('execa');
+
+describe('cli/tools/vp', () => {
+  describe('release assets', () => {
+    test.each([
+      ['amd64', 'vp-x86_64-unknown-linux-gnu.tar.gz'],
+      ['arm64', 'vp-aarch64-unknown-linux-gnu.tar.gz'],
+    ] as const)('maps %s to the official release asset', (arch, expected) => {
+      expect(vitePlusAssetName(arch)).toBe(expected);
+    });
+
+    test('selects an exact release asset checksum', () => {
+      expect(
+        parseVitePlusChecksum(
+          [
+            'a'.repeat(64) + '  vp-aarch64-unknown-linux-gnu.tar.gz',
+            'b'.repeat(64) + '  vp-x86_64-unknown-linux-gnu.tar.gz',
+            '',
+          ].join('\n'),
+          'vp-x86_64-unknown-linux-gnu.tar.gz',
+        ),
+      ).toBe('b'.repeat(64));
+    });
+
+    test('rejects missing or malformed checksums', () => {
+      expect(() =>
+        parseVitePlusChecksum('', 'vp-x86_64-unknown-linux-gnu.tar.gz'),
+      ).toThrow('Cannot find checksum');
+      expect(() =>
+        parseVitePlusChecksum(
+          'not-a-checksum  vp-x86_64-unknown-linux-gnu.tar.gz',
+          'vp-x86_64-unknown-linux-gnu.tar.gz',
+        ),
+      ).toThrow('Cannot find checksum');
+    });
+  });
+
+  describe('VpInstallService', () => {
+    let child: Container;
+    let service: VpInstallService;
+
+    beforeAll(async () => {
+      await ensurePaths([
+        'opt/containerbase/bin',
+        'opt/containerbase/tools',
+        'tmp/containerbase',
+        'var/lib/containerbase',
+      ]);
+    });
+
+    beforeEach(async () => {
+      child = await testContainer();
+      child.bind(HttpService).toSelf();
+      child.bind(CompressionService).toSelf();
+      child.bind(LinkToolService).toSelf();
+      child.bind(VpInstallService).toSelf();
+      service = await child.getAsync(VpInstallService);
+    });
+
+    test('downloads, verifies, and extracts the exact prebuilt release', async () => {
+      const filename = vitePlusAssetName(
+        arch() === 'arm64' ? 'arm64' : 'amd64',
+      );
+      const checksum = 'c'.repeat(64);
+      const checksumFile = join(globalThis.cacheDir, 'vp-checksums.txt');
+      const archiveFile = join(globalThis.cacheDir, filename);
+      await fs.writeFile(checksumFile, `${checksum}  ${filename}\n`);
+      await fs.writeFile(archiveFile, 'archive');
+
+      const download = vi
+        .spyOn(HttpService.prototype, 'download')
+        .mockResolvedValueOnce(checksumFile)
+        .mockResolvedValueOnce(archiveFile);
+      vi.spyOn(HttpService.prototype, 'exists').mockResolvedValueOnce(true);
+      const extract = vi
+        .spyOn(CompressionService.prototype, 'extract')
+        .mockResolvedValueOnce();
+
+      await service.install('0.4.0');
+
+      expect(download).toHaveBeenNthCalledWith(1, {
+        url: 'https://github.com/voidzero-dev/vite-plus/releases/download/v0.4.0/vp-checksums.txt',
+      });
+      expect(download).toHaveBeenNthCalledWith(2, {
+        url: `https://github.com/voidzero-dev/vite-plus/releases/download/v0.4.0/${filename}`,
+        checksumType: 'sha256',
+        expectedChecksum: checksum,
+      });
+      expect(extract).toHaveBeenCalledWith({
+        file: archiveFile,
+        cwd: expect.stringMatching(/\/vp\/0\.4\.0\/bin$/),
+      });
+    });
+
+    test('rejects releases that predate the bundled planner', async () => {
+      vi.spyOn(HttpService.prototype, 'exists').mockResolvedValueOnce(false);
+      const download = vi.spyOn(HttpService.prototype, 'download');
+
+      await expect(service.install('0.3.0')).rejects.toThrow(
+        `${VP_SYNC_VERSIONS_UNAVAILABLE}:0.3.0`,
+      );
+      expect(download).not.toHaveBeenCalled();
+    });
+
+    test('links vp with the Node runtime needed by the bundled planner', async () => {
+      const shellwrapper = vi
+        .spyOn(LinkToolService.prototype, 'shellwrapper')
+        .mockResolvedValueOnce();
+
+      await service.link('0.4.0');
+
+      expect(shellwrapper).toHaveBeenCalledWith('vp', {
+        srcDir: expect.stringMatching(/\/vp\/0\.4\.0\/bin$/),
+        extraToolEnvs: ['node'],
+      });
+    });
+
+    test('checks the installed vp version', async () => {
+      await expect(service.test('0.4.0')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/cli/tools/vp.ts
+++ b/src/cli/tools/vp.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { injectFromHierarchy, injectable } from 'inversify';
+import { BaseInstallService } from '../install-tool/base-install.service.ts';
+import type { Arch } from '../utils/index.ts';
+
+// Stable machine-readable marker consumed by Renovate. Do not reword it.
+export const VP_SYNC_VERSIONS_UNAVAILABLE =
+  'CONTAINERBASE_VP_SYNC_VERSIONS_UNAVAILABLE';
+
+export function vitePlusAssetName(arch: Arch): string {
+  const target = arch === 'arm64' ? 'aarch64' : 'x86_64';
+  return `vp-${target}-unknown-linux-gnu.tar.gz`;
+}
+
+export function parseVitePlusChecksum(
+  checksums: string,
+  filename: string,
+): string {
+  for (const line of checksums.split('\n')) {
+    const match = /^([a-f\d]{64})\s+\*?(.+)$/i.exec(line.trim());
+    const checksum = match?.[1];
+    if (checksum && match?.[2] === filename) {
+      return checksum.toLowerCase();
+    }
+  }
+  throw new Error(`Cannot find checksum for '${filename}' in vp-checksums.txt`);
+}
+
+@injectable()
+@injectFromHierarchy()
+export class VpInstallService extends BaseInstallService {
+  readonly name = 'vp';
+  override readonly parent = 'node';
+
+  override async install(version: string): Promise<void> {
+    const baseUrl = `https://github.com/voidzero-dev/vite-plus/releases/download/v${version}/`;
+    const filename = vitePlusAssetName(this.envSvc.arch);
+    const checksumUrl = `${baseUrl}vp-checksums.txt`;
+
+    if (!(await this.http.exists(checksumUrl))) {
+      throw new Error(
+        `${VP_SYNC_VERSIONS_UNAVAILABLE}:${version}: Vite+ release does not provide the sync-versions planner`,
+      );
+    }
+
+    const checksumFile = await this.http.download({
+      url: checksumUrl,
+    });
+    const expectedChecksum = parseVitePlusChecksum(
+      await fs.readFile(checksumFile, 'utf8'),
+      filename,
+    );
+    const file = await this.http.download({
+      url: `${baseUrl}${filename}`,
+      checksumType: 'sha256',
+      expectedChecksum,
+    });
+
+    await this.pathSvc.ensureToolPath(this.name);
+    const path = join(
+      await this.pathSvc.createVersionedToolPath(this.name, version),
+      'bin',
+    );
+    await fs.mkdir(path);
+    await this.compress.extract({ file, cwd: path });
+  }
+
+  override async link(version: string): Promise<void> {
+    const src = join(this.pathSvc.versionedToolPath(this.name, version), 'bin');
+    await this.shellwrapper({ srcDir: src, extraToolEnvs: ['node'] });
+  }
+
+  override async test(_version: string): Promise<void> {
+    await this._spawn(this.name, ['--version']);
+  }
+}

--- a/test/Dockerfile.distro
+++ b/test/Dockerfile.distro
@@ -211,6 +211,13 @@ RUN install-tool pnpm 10.34.5
 # renovate: datasource=npm packageName=@yarnpkg/cli-dist
 RUN install-tool yarn 4.18.0
 
+# renovate: datasource=github-releases depName=vp packageName=voidzero-dev/vite-plus
+ARG VP_VERSION=0.3.1
+RUN install-tool vp "${VP_VERSION}"
+
+COPY test/vp/sync-versions.mjs /test/vp-sync-versions.mjs
+RUN node /test/vp-sync-versions.mjs "${VP_VERSION}"
+
 #--------------------------------------
 # Image: test-php
 #--------------------------------------

--- a/test/latest/Dockerfile
+++ b/test/latest/Dockerfile
@@ -387,6 +387,25 @@ RUN install-tool nuget 7.6.0
 RUN nuget search nuget.commandline -Take 1
 
 #--------------------------------------
+# Image: vp
+#--------------------------------------
+FROM base AS test-vp
+
+# renovate: datasource=github-releases packageName=containerbase/node-prebuild versioning=node
+RUN install-tool node 24.19.0
+
+# renovate: datasource=github-releases depName=vp packageName=voidzero-dev/vite-plus
+ARG VP_VERSION=0.3.1
+RUN install-tool vp "${VP_VERSION}"
+
+COPY test/vp/sync-versions.mjs /test/vp-sync-versions.mjs
+
+USER 12021
+SHELL ["/bin/sh", "-c"]
+
+RUN node /test/vp-sync-versions.mjs "${VP_VERSION}"
+
+#--------------------------------------
 # final
 #--------------------------------------
 FROM base
@@ -399,3 +418,4 @@ COPY --link --from=teste /.dummy /.dummy
 COPY --link --from=testf /.dummy /.dummy
 COPY --link --from=test-docker /.dummy /.dummy
 COPY --link --from=test-mono /.dummy /.dummy
+COPY --link --from=test-vp /.dummy /.dummy

--- a/test/latest/Dockerfile.arm64
+++ b/test/latest/Dockerfile.arm64
@@ -214,6 +214,25 @@ RUN install-tool protoc 35.1
 RUN install-tool pixi v0.76.2
 
 #--------------------------------------
+# Image: vp
+#--------------------------------------
+FROM base AS test-vp
+
+# renovate: datasource=github-releases packageName=containerbase/node-prebuild versioning=node
+RUN install-tool node 24.19.0
+
+# renovate: datasource=github-releases depName=vp packageName=voidzero-dev/vite-plus
+ARG VP_VERSION=0.3.1
+RUN install-tool vp "${VP_VERSION}"
+
+COPY test/vp/sync-versions.mjs /test/vp-sync-versions.mjs
+
+USER 12021
+SHELL ["/bin/sh", "-c"]
+
+RUN node /test/vp-sync-versions.mjs "${VP_VERSION}"
+
+#--------------------------------------
 # Image: final
 #--------------------------------------
 FROM base
@@ -235,5 +254,6 @@ COPY --from=test-mono /.dummy /.dummy
 COPY --from=test-terraform /.dummy /.dummy
 COPY --from=test-tofu /.dummy /.dummy
 COPY --from=test-vendir /.dummy /.dummy
+COPY --from=test-vp /.dummy /.dummy
 
 COPY --from=test-others /.dummy /.dummy

--- a/test/vp/sync-versions.mjs
+++ b/test/vp/sync-versions.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const version = process.argv[2];
+assert.ok(version, 'Expected the installed Vite+ version');
+
+const cwd = mkdtempSync(join(tmpdir(), 'containerbase-vp-'));
+const manifest = {
+  name: 'vp-install-test',
+  private: true,
+  scripts: { postinstall: 'exit 91' },
+  devDependencies: {
+    'vite-plus': '0.0.0',
+    vite: 'npm:@voidzero-dev/vite-plus-core@0.0.0',
+    vitest: '0.0.0',
+    '@vitest/coverage-v8': '0.0.0',
+    typescript: '5.8.0',
+  },
+};
+const contents = JSON.stringify(manifest, null, 2) + '\n';
+const config = 'throw new Error("Project configuration must not be loaded");\n';
+
+function plan(manifestContents) {
+  return JSON.parse(
+    execFileSync(process.env.VP_TEST_BIN ?? 'vp', ['sync-versions', '--json'], {
+      cwd,
+      encoding: 'utf8',
+      input: JSON.stringify({
+        schemaVersion: 1,
+        workspace: '.',
+        manifests: [
+          {
+            path: 'package.json',
+            kind: 'packageJson',
+            contents: manifestContents,
+          },
+        ],
+      }),
+    }),
+  );
+}
+
+try {
+  writeFileSync(join(cwd, 'package.json'), contents);
+  writeFileSync(join(cwd, 'vite.config.mjs'), config);
+
+  const result = plan(contents);
+  assert.equal(result.schemaVersion, 1);
+  assert.deepEqual(result.tool, { name: 'vite-plus', version });
+  assert.equal(result.workspace, '.');
+  assert.equal(result.replacements.length, 1);
+
+  const replacement = result.replacements[0];
+  assert.equal(replacement.path, 'package.json');
+  assert.equal(replacement.kind, 'packageJson');
+  assert.equal(replacement.before, contents);
+
+  const updated = JSON.parse(replacement.after);
+  const vitestVersion = updated.devDependencies.vitest;
+  assert.match(vitestVersion, /^\d+\.\d+\.\d+/);
+  assert.notEqual(vitestVersion, '0.0.0');
+  assert.deepEqual(updated, {
+    ...manifest,
+    devDependencies: {
+      ...manifest.devDependencies,
+      'vite-plus': version,
+      vite: `npm:@voidzero-dev/vite-plus-core@${version}`,
+      vitest: vitestVersion,
+      '@vitest/coverage-v8': vitestVersion,
+    },
+  });
+
+  assert.deepEqual(plan(replacement.after), {
+    schemaVersion: 1,
+    tool: { name: 'vite-plus', version },
+    workspace: '.',
+    replacements: [],
+  });
+  assert.equal(readFileSync(join(cwd, 'package.json'), 'utf8'), contents);
+  assert.equal(readFileSync(join(cwd, 'vite.config.mjs'), 'utf8'), config);
+} finally {
+  rmSync(cwd, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Containerbase can install an exact Vite+ release as `vp`, giving downstream tools a verified way to run the compatibility planner owned by that release.

This is the second part of the Vite+ dependency-alignment integration. The planner from voidzero-dev/vite-plus#2600 is now available in Vite+ 0.3.1. The downstream Renovate integration is in renovatebot/renovate#45630.

## Design

- Installation selects the official archive for the current Linux architecture and validates it against `vp-checksums.txt`.
- The extracted `vp`, planner sidecar, and toolchain manifest retain the release layout expected by the global CLI.
- Vite+ declares Node as its parent tool so the JavaScript planner always has a compatible runtime.
- Releases that predate the planner contract return a stable marker. Renovate can treat that case as unsupported instead of as a failed update.

## Validation

- All 141 Vitest tests passed, including the 8 Vite+ installer tests.
- Formatting, ESLint, both TypeScript configurations, Markdown lint, and `git diff --check` passed.
- The CLI build passed. Both Node Docker test images (`linux/amd64` and `linux/arm64`) installed Vite+ 0.3.1 and ran the bundled `sync-versions --json` planner as a non-root user.
- The planner smoke test checks dependency alignment, repeat execution, and unchanged project files. A deliberately wrong expected version failed as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing, linking, and testing the Vite+ (`vp`) tool.
  - Added architecture-specific downloads with checksum verification.
  - Added version synchronization for Vite+, Vite, Vitest, and coverage tooling.

- **Documentation**
  - Documented Vite+ release archives and checksum locations for supported Linux architectures.

- **Tests**
  - Added integration and container coverage for Vite+ installation and version synchronization.
  - Added validation for supported architectures, checksums, downloads, linking, and version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
